### PR TITLE
Extracted AbstractSplitter

### DIFF
--- a/src/RAG/Splitter/AbstractSplitter.php
+++ b/src/RAG/Splitter/AbstractSplitter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\RAG\Splitter;
+
+use NeuronAI\RAG\Document;
+
+abstract class AbstractSplitter implements SplitterInterface
+{
+    /**
+     * @param  Document[]  $documents
+     * @return Document[]
+     */
+    public function splitDocuments(array $documents): array
+    {
+        $split = [];
+
+        foreach ($documents as $document) {
+            $split = \array_merge($split, $this->splitDocument($document));
+        }
+
+        return $split;
+    }
+}

--- a/src/RAG/Splitter/DelimiterTextSplitter.php
+++ b/src/RAG/Splitter/DelimiterTextSplitter.php
@@ -6,7 +6,7 @@ namespace NeuronAI\RAG\Splitter;
 
 use NeuronAI\RAG\Document;
 
-class DelimiterTextSplitter implements SplitterInterface
+class DelimiterTextSplitter extends AbstractSplitter
 {
     public function __construct(private readonly int $maxLength = 1000, private readonly string $separator = ' ', private readonly int $wordOverlap = 0)
     {
@@ -37,21 +37,6 @@ class DelimiterTextSplitter implements SplitterInterface
             $newDocument->sourceType = $document->getSourceType();
             $newDocument->sourceName = $document->getSourceName();
             $split[] = $newDocument;
-        }
-
-        return $split;
-    }
-
-    /**
-     * @param  Document[]  $documents
-     * @return Document[]
-     */
-    public function splitDocuments(array $documents): array
-    {
-        $split = [];
-
-        foreach ($documents as $document) {
-            $split = \array_merge($split, $this->splitDocument($document));
         }
 
         return $split;

--- a/src/RAG/Splitter/SentenceTextSplitter.php
+++ b/src/RAG/Splitter/SentenceTextSplitter.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
  * Splits text into sentences, groups into word-based chunks, and applies
  * overlap in terms of words.
  */
-class SentenceTextSplitter implements SplitterInterface
+class SentenceTextSplitter extends AbstractSplitter
 {
     private readonly int $maxWords;
     private readonly int $overlapWords;
@@ -90,19 +90,6 @@ class SentenceTextSplitter implements SplitterInterface
         }
 
         return $split;
-    }
-
-    /**
-     * @param  array<Document>  $documents
-     * @return array<Document>
-     */
-    public function splitDocuments(array $documents): array
-    {
-        $result = [];
-        foreach ($documents as $document) {
-            $result = \array_merge($result, $this->splitDocument($document));
-        }
-        return $result;
     }
 
     /**


### PR DESCRIPTION
This refactor introduces an `AbstractSplitter` that encapsulates the shared `splitDocuments()` logic previously duplicated in both `DelimiterTextSplitter` and `SentenceTextSplitter`. By moving the common code up into a single parent class, we keep the public APIs unchanged while eliminating repetition, making future maintenance and the creation of new splitters simpler and less error-prone.