### PR TITLE
Add withMetadata() API for response metadata persistence and streaming

### DIFF
--- a/src/Agent/Nodes/ChatNode.php
+++ b/src/Agent/Nodes/ChatNode.php
@@ -50,6 +50,13 @@ class ChatNode extends Node
             return new ToolCallEvent($response, $event);
         }
 
+        // Attach response metadata to the message for persistence
+        foreach ($state->getResponseMetadata() as $key => $value) {
+            if ($value !== null && $value !== '' && $value !== []) {
+                $response->addMetadata($key, $value);
+            }
+        }
+
         // Add the final response to chat history (after tool loop)
         $this->addToChatHistory($state, $response);
 

--- a/src/Agent/Nodes/StreamingNode.php
+++ b/src/Agent/Nodes/StreamingNode.php
@@ -61,6 +61,13 @@ class StreamingNode extends Node
                 return new ToolCallEvent($message, $event);
             }
 
+            // Attach response metadata to the message for persistence
+            foreach ($state->getResponseMetadata() as $key => $value) {
+                if ($value !== null && $value !== '' && $value !== []) {
+                    $message->addMetadata($key, $value);
+                }
+            }
+
             // Add the final message to the chat history (after tool loop)
             $this->addToChatHistory($state, $message);
 

--- a/src/Chat/Messages/Stream/Adapters/AGUIAdapter.php
+++ b/src/Chat/Messages/Stream/Adapters/AGUIAdapter.php
@@ -167,6 +167,19 @@ class AGUIAdapter extends SSEAdapter
             'threadId' => $this->threadId,
             'timestamp' => $this->timestamp(),
         ]);
+
+        foreach ($this->metadata as $key => $value) {
+            if (empty($value)) {
+                continue;
+            }
+
+            yield $this->sse([
+                'type' => 'Custom',
+                'name' => $key,
+                'value' => $value,
+                'timestamp' => $this->timestamp(),
+            ]);
+        }
     }
 
     public function end(): iterable

--- a/src/Chat/Messages/Stream/Adapters/SSEAdapter.php
+++ b/src/Chat/Messages/Stream/Adapters/SSEAdapter.php
@@ -17,6 +17,14 @@ use function json_encode;
  */
 abstract class SSEAdapter implements StreamAdapterInterface
 {
+    /** @var array<string, mixed> */
+    protected array $metadata = [];
+
+    public function setMetadata(array $metadata): void
+    {
+        $this->metadata = $metadata;
+    }
+
     /**
      * Format data as a Server-Sent Event.
      *

--- a/src/Chat/Messages/Stream/Adapters/StreamAdapterInterface.php
+++ b/src/Chat/Messages/Stream/Adapters/StreamAdapterInterface.php
@@ -34,4 +34,11 @@ interface StreamAdapterInterface
      * @return iterable<string>
      */
     public function end(): iterable;
+
+    /**
+     * Set application-level metadata to be emitted during streaming.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public function setMetadata(array $metadata): void;
 }

--- a/src/Chat/Messages/Stream/Adapters/VercelAIAdapter.php
+++ b/src/Chat/Messages/Stream/Adapters/VercelAIAdapter.php
@@ -95,7 +95,28 @@ class VercelAIAdapter extends SSEAdapter
 
     public function start(): iterable
     {
-        return [];
+        foreach ($this->metadata as $key => $value) {
+            if (empty($value)) {
+                continue;
+            }
+
+            if ($key === 'sources') {
+                foreach ($value as $source) {
+                    yield $this->sse([
+                        'type' => 'source-url',
+                        'sourceId' => $this->generateId('src'),
+                        'url' => $source['url'] ?? '',
+                        'title' => $source['title'] ?? '',
+                    ]);
+                }
+            } else {
+                yield $this->sse([
+                    'type' => 'data-' . $key,
+                    'id' => $this->generateId('data'),
+                    'data' => $value,
+                ]);
+            }
+        }
     }
 
     public function end(): iterable

--- a/src/Workflow/WorkflowHandler.php
+++ b/src/Workflow/WorkflowHandler.php
@@ -15,10 +15,22 @@ class WorkflowHandler implements WorkflowHandlerInterface
 {
     protected WorkflowState $result;
 
+    /** @var array<string, mixed> */
+    protected array $metadata = [];
+
     public function __construct(
         protected Workflow $workflow,
         protected ?InterruptRequest $resumeRequest = null
     ) {
+    }
+
+    /**
+     * Attach application-level metadata for persistence and streaming.
+     */
+    public function withMetadata(string $key, mixed $value): static
+    {
+        $this->metadata[$key] = $value;
+        return $this;
     }
 
     /**
@@ -31,6 +43,17 @@ class WorkflowHandler implements WorkflowHandlerInterface
      */
     public function events(?StreamAdapterInterface $adapter = null): Generator
     {
+        // Pass metadata to state for persistence
+        $state = $this->workflow->resolveState();
+        foreach ($this->metadata as $k => $v) {
+            $state->addResponseMetadata($k, $v);
+        }
+
+        // Pass metadata to adapter for streaming
+        if ($adapter instanceof StreamAdapterInterface && $this->metadata !== []) {
+            $adapter->setMetadata($this->metadata);
+        }
+
         // Protocol start (if adapter provided)
         if ($adapter instanceof StreamAdapterInterface) {
             foreach ($adapter->start() as $output) {

--- a/src/Workflow/WorkflowState.php
+++ b/src/Workflow/WorkflowState.php
@@ -48,4 +48,16 @@ class WorkflowState
     {
         return $this->data;
     }
+
+    protected array $responseMetadata = [];
+
+    public function addResponseMetadata(string $key, mixed $value): void
+    {
+        $this->responseMetadata[$key] = $value;
+    }
+
+    public function getResponseMetadata(): array
+    {
+        return $this->responseMetadata;
+    }
 }


### PR DESCRIPTION
WorkflowHandler gains withMetadata() to attach app-level metadata. Metadata flows to WorkflowState (for Message persistence via nodes) and to StreamAdapterInterface (for SSE emission via adapters).