### PR TITLE
Allow proper union types inside of structured outputs

### DIFF
--- a/src/StructuredOutput/Deserializer/Deserializer.php
+++ b/src/StructuredOutput/Deserializer/Deserializer.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace NeuronAI\StructuredOutput\Deserializer;
 
 use BackedEnum;
-use NeuronAI\StaticConstructor;
-use NeuronAI\StructuredOutput\SchemaProperty;
 use DateTime;
 use DateTimeImmutable;
 use Exception;
+use NeuronAI\StaticConstructor;
+use NeuronAI\StructuredOutput\SchemaProperty;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionNamedType;
@@ -38,6 +38,7 @@ use function preg_replace;
 use function str_replace;
 use function strtolower;
 use function ucwords;
+use function array_search;
 
 use const JSON_ERROR_NONE;
 
@@ -64,7 +65,7 @@ class Deserializer
         $data = json_decode($jsonData, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new DeserializerException('Invalid JSON: '.json_last_error_msg());
+            throw new DeserializerException('Invalid JSON: ' . json_last_error_msg());
         }
 
         return $this->deserializeObject($data, $className);
@@ -112,7 +113,7 @@ class Deserializer
 
                 // Track any promoted arguments that are being set
                 if ($property->isPromoted()) {
-                    $promotedArgs[ $propertyName ] = $value;
+                    $promotedArgs[$propertyName] = $value;
                 }
             }
         }
@@ -159,15 +160,30 @@ class Deserializer
     protected function castValue(mixed $value, ReflectionType $type, ReflectionProperty $property): mixed
     {
         if ($type instanceof ReflectionUnionType) {
-            // Handle union types
-            foreach ($type->getTypes() as $unionType) {
-                try {
-                    return $this->castToSingleType($value, $unionType, $property);
-                } catch (Exception) {
-                    continue;
+            // Figure out what type the data is.
+            $dataType = str_replace('double', 'float', gettype($value));
+            $typesInUnion = array_map(fn (ReflectionNamedType $t) => $t->getName(), $type->getTypes());
+
+            // Try casting to the data type if it exists in the union.
+            try {
+                return $this->castToSingleType(
+                    $value,
+                    $type->getTypes()[array_search($dataType, $typesInUnion, true)],
+                    $property,
+                );
+            } catch (Exception) {
+                // Fallthrough method that tries each type in order for success.
+                foreach ($type->getTypes() as $unionType) {
+                    try {
+                        return $this->castToSingleType($value, $unionType, $property);
+                    } catch (Exception) {
+                        continue;
+                    }
                 }
+                throw new DeserializerException(
+                    "Cannot cast value to any type in union for property {$property->getName()}",
+                );
             }
-            throw new DeserializerException("Cannot cast value to any type in union for property {$property->getName()}");
         }
 
         // @phpstan-ignore-next-line
@@ -182,7 +198,7 @@ class Deserializer
     protected function castToSingleType(
         mixed $value,
         ReflectionNamedType $type,
-        ReflectionProperty $property
+        ReflectionProperty $property,
     ): mixed {
         $typeName = $type->getName();
 
@@ -240,10 +256,16 @@ class Deserializer
                 if (count($attribute->anyOf) === 1) {
                     $elementType = $attribute->anyOf[0];
                     if (class_exists($elementType)) {
-                        return array_map(fn (array $item): object => $this->deserializeObject($item, $elementType), $value);
+                        return array_map(
+                            fn (array $item): object => $this->deserializeObject($item, $elementType),
+                            $value
+                        );
                     }
                 } else {
-                    return array_map(fn (array $item): object => $this->deserializeObjectWithDiscriminator($item, $attribute->anyOf), $value);
+                    return array_map(
+                        fn (array $item): object => $this->deserializeObjectWithDiscriminator($item, $attribute->anyOf),
+                        $value,
+                    );
                 }
             }
         }
@@ -262,7 +284,9 @@ class Deserializer
     {
         // Check for the discriminator field
         if (!isset($data[$this->discriminator])) {
-            throw new DeserializerException("Missing {$this->discriminator} discriminator field in data for multi-type array deserialization");
+            throw new DeserializerException(
+                "Missing {$this->discriminator} discriminator field in data for multi-type array deserialization",
+            );
         }
 
         $discriminatorValue = strtolower((string) $data[$this->discriminator]);
@@ -276,7 +300,12 @@ class Deserializer
 
         // Find a matching class
         if (!isset($mapping[$discriminatorValue])) {
-            throw new DeserializerException("Unknown discriminator value '{$discriminatorValue}'. Expected one of: " . implode(', ', array_keys($mapping)));
+            throw new DeserializerException(
+                "Unknown discriminator value '{$discriminatorValue}'. Expected one of: " . implode(
+                    ', ',
+                    array_keys($mapping),
+                ),
+            );
         }
 
         $className = $mapping[$discriminatorValue];
@@ -308,10 +337,10 @@ class Deserializer
         }
 
         if (is_numeric($value)) {
-            return new DateTime('@'.$value);
+            return new DateTime('@' . $value);
         }
 
-        throw new DeserializerException("Cannot create DateTime from value type: ".gettype($value));
+        throw new DeserializerException("Cannot create DateTime from value type: " . gettype($value));
     }
 
     /**
@@ -334,10 +363,10 @@ class Deserializer
         }
 
         if (is_numeric($value)) {
-            return new DateTimeImmutable('@'.$value);
+            return new DateTimeImmutable('@' . $value);
         }
 
-        throw new DeserializerException("Cannot create DateTimeImmutable from value type: ".gettype($value));
+        throw new DeserializerException("Cannot create DateTimeImmutable from value type: " . gettype($value));
     }
 
     protected function handleEnum(BackedEnum|string $typeName, mixed $value): BackedEnum

--- a/src/StructuredOutput/JsonSchema.php
+++ b/src/StructuredOutput/JsonSchema.php
@@ -11,6 +11,7 @@ use ReflectionEnumBackedCase;
 use ReflectionException;
 use ReflectionNamedType;
 use ReflectionProperty;
+use ReflectionUnionType;
 
 use function array_merge;
 use function array_pop;
@@ -20,9 +21,9 @@ use function class_exists;
 use function count;
 use function enum_exists;
 use function in_array;
+use function is_array;
 use function str_replace;
 use function strtolower;
-use function is_array;
 
 /**
  * @method static static make(string $discriminator = '__classname__')
@@ -43,7 +44,7 @@ class JsonSchema
     /**
      * Generate JSON schema from a PHP class
      *
-     * @param string $class Fully qualified class name
+     * @param  string  $class  Fully qualified class name
      * @return array JSON schema definition
      * @throws ReflectionException
      */
@@ -62,7 +63,7 @@ class JsonSchema
     /**
      * Generate schema for a class
      *
-     * @param string $class Class name
+     * @param  string  $class  Class name
      * @return array The schema
      * @throws ReflectionException
      */
@@ -157,12 +158,17 @@ class JsonSchema
 
         /** @var ?ReflectionNamedType $type */
         $type = $property->getType();
-        $typeName = $type?->getName();
 
         // Handle default values
         if ($property->hasDefaultValue()) {
             $schema['default'] = $property->getDefaultValue();
         }
+
+        if ($type instanceof ReflectionUnionType) {
+            return array_merge($schema, $this->processUnionType($type));
+        }
+
+        $typeName = $type?->getName();
 
         // Process different types
         if ($typeName === 'array') {
@@ -188,18 +194,15 @@ class JsonSchema
                     $schema['maxItems'] = $attribute->max;
                 }
             }
-        }
-        // Handle enum types
+        } // Handle enum types
         elseif ($typeName && enum_exists($typeName)) {
             $enumReflection = new ReflectionEnum($typeName);
             $schema = array_merge($schema, $this->processEnum($enumReflection));
-        }
-        // Handle class types
+        } // Handle class types
         elseif ($typeName && class_exists($typeName)) {
             $classSchema = $this->generateClassSchema($typeName);
             $schema = array_merge($schema, $classSchema);
-        }
-        // Handle basic types
+        } // Handle basic types
         elseif ($typeName) {
             $typeSchema = $this->getBasicTypeSchema($typeName);
             $schema = array_merge($schema, $typeSchema);
@@ -230,7 +233,8 @@ class JsonSchema
         }
 
         // Handle nullable types - for basic types only
-        if ($type && $type->allowsNull() && isset($schema['type']) && !isset($schema['$ref']) && !isset($schema['allOf'])) {
+        if ($type && $type->allowsNull(
+        ) && isset($schema['type']) && !isset($schema['$ref']) && !isset($schema['allOf'])) {
             if (is_array($schema['type'])) {
                 if (!in_array('null', $schema['type'])) {
                     $schema['type'][] = 'null';
@@ -269,6 +273,24 @@ class JsonSchema
         return $schema;
     }
 
+    /*
+     * Process a union type to generate its schema
+     */
+    protected function processUnionType(ReflectionUnionType $type): array
+    {
+        $schema = [];
+        foreach ($type->getTypes() as $namedType) {
+            $basicTypeSchema = $this->getBasicTypeSchema($namedType->getName());
+            $schema['type'][] = $basicTypeSchema['type'];
+
+            if ($basicTypeSchema['type'] === 'array') {
+                $schema['items'] = $basicTypeSchema['items'];
+            }
+        }
+
+        return $schema;
+    }
+
     /**
      * Get the Property attribute if it exists on a property
      */
@@ -284,7 +306,7 @@ class JsonSchema
     /**
      * Get schema for a basic PHP type
      *
-     * @param string $type PHP type name
+     * @param  string  $type  PHP type name
      * @return array Schema for the type
      * @throws ReflectionException
      */
@@ -312,6 +334,9 @@ class JsonSchema
                     'items' => ['type' => 'string'],
                 ];
 
+            case 'null':
+                return ['type' => 'null'];
+
             default:
                 // Check if it's a class or enum
                 if (class_exists($type)) {
@@ -330,7 +355,7 @@ class JsonSchema
     /**
      * Generate anyOf schema for multiple class/enum types
      *
-     * @param array $types Array of class/enum type strings
+     * @param  array  $types  Array of class/enum type strings
      * @return array Schema with anyOf structure
      * @throws ReflectionException
      */
@@ -363,8 +388,8 @@ class JsonSchema
     /**
      * Inject __classname__ discriminator field into schema
      *
-     * @param array $schema The schema to inject into
-     * @param string $discriminatorValue The discriminator value (lowercase class name)
+     * @param  array  $schema  The schema to inject into
+     * @param  string  $discriminatorValue  The discriminator value (lowercase class name)
      * @return array Modified schema
      */
     protected function injectDiscriminator(array $schema, string $discriminatorValue): array
@@ -376,7 +401,7 @@ class JsonSchema
                 $this->discriminator => [
                     'type' => 'string',
                     'enum' => [$discriminatorValue],
-                    'description' => 'This property is mandatory and can only be filled with "'.$discriminatorValue.'". It is used as a discriminator for class type resolution.',
+                    'description' => 'This property is mandatory and can only be filled with "' . $discriminatorValue . '". It is used as a discriminator for class type resolution.',
                 ],
                 ...($schema['properties'] ?? []),
             ];

--- a/tests/DeserializerTest.php
+++ b/tests/DeserializerTest.php
@@ -294,4 +294,69 @@ class DeserializerTest extends TestCase
 
         Deserializer::make()->fromJson($json, $class::class);
     }
+
+    public function test_deserialize_with_union_types_returns_default(): void
+    {
+        $class = new class () {
+            #[SchemaProperty(description: "Current value", required: true)]
+            public int|float|null $currentValue = null;
+        };
+
+        $json = '{}';
+
+        $obj = Deserializer::make()->fromJson($json, $class::class);
+
+        $this->assertEquals(null, $obj->currentValue);
+    }
+
+    public function test_deserialize_with_union_types_returns_type_1(): void
+    {
+        $class = new class () {
+            #[SchemaProperty(description: "Current value", required: true)]
+            public int|float|null $currentValue = null;
+        };
+
+        $json = '{"currentValue": 42}';
+
+        $obj = Deserializer::make()->fromJson($json, $class::class);
+
+        $this->assertEquals(42, $obj->currentValue);
+        $this->assertIsInt($obj->currentValue);
+    }
+
+    public function test_deserialize_with_union_types_returns_type_2(): void
+    {
+        $class = new class () {
+            #[SchemaProperty(description: "Current value", required: true)]
+            public int|float|null $currentValue = null;
+        };
+
+        $json = '{"currentValue": 42.69}';
+
+        $obj = Deserializer::make()->fromJson($json, $class::class);
+
+        $this->assertEquals(42.69, $obj->currentValue);
+        $this->assertIsFloat($obj->currentValue);
+    }
+
+    public function test_deserialize_with_union_types_returns_type_1_with_incorrect_data(): void
+    {
+        $class = new class () {
+            #[SchemaProperty(description: "Current value", required: true)]
+            public int|float|null $currentValue = null;
+        };
+
+        $json = '{"currentValue": "1"}';
+
+        $obj = Deserializer::make()->fromJson($json, $class::class);
+
+        $this->assertEquals(1, $obj->currentValue);
+        $this->assertIsInt($obj->currentValue);
+
+        $json = '{"currentValue": "wow"}';
+
+        $obj = Deserializer::make()->fromJson($json, $class::class);
+
+        $this->assertIsInt($obj->currentValue);
+    }
 }

--- a/tests/JsonSchemaTest.php
+++ b/tests/JsonSchemaTest.php
@@ -8,9 +8,11 @@ use NeuronAI\StructuredOutput\JsonSchema;
 use NeuronAI\StructuredOutput\SchemaProperty;
 use NeuronAI\StructuredOutput\Validation\Rules\ArrayOf;
 use NeuronAI\Tests\Stubs\StructuredOutput\EmailMode;
+use NeuronAI\Tests\Stubs\StructuredOutput\ExampleStructure;
 use NeuronAI\Tests\Stubs\StructuredOutput\FtpMode;
 use NeuronAI\Tests\Stubs\StructuredOutput\ImageBlock;
 use NeuronAI\Tests\Stubs\StructuredOutput\Person;
+use NeuronAI\Tests\Stubs\StructuredOutput\Tag;
 use NeuronAI\Tests\Stubs\StructuredOutput\TextBlock;
 use NeuronAI\Tests\Stubs\StructuredOutput\User;
 use PHPUnit\Framework\TestCase;
@@ -40,6 +42,7 @@ class JsonSchemaTest extends TestCase
             'additionalProperties' => false,
         ], $schema);
     }
+
     public function test_with_nullable_properties(): void
     {
         $class = new class () {
@@ -427,6 +430,30 @@ class JsonSchemaTest extends TestCase
         ], $schema);
     }
 
+    public function test_float_constraints(): void
+    {
+        $class = new class () {
+            #[SchemaProperty(description: "A rating", min: 1, max: 5)]
+            public float $rating;
+        };
+
+        $schema = (new JsonSchema())->generate($class::class);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'rating' => [
+                    'description' => 'A rating',
+                    'type' => 'number',
+                    'minimum' => 1,
+                    'maximum' => 5,
+                ]
+            ],
+            'required' => ['rating'],
+            'additionalProperties' => false,
+        ], $schema);
+    }
+
     public function test_array_constraints(): void
     {
         $class = new class () {
@@ -448,6 +475,90 @@ class JsonSchemaTest extends TestCase
                 ]
             ],
             'required' => ['tags'],
+            'additionalProperties' => false,
+        ], $schema);
+    }
+
+    public function test_union_types(): void
+    {
+        $class = new class () {
+            #[SchemaProperty(description: "Current value", required: true)]
+            public int|float|null $currentValue = null;
+
+            #[SchemaProperty(description: "Target value", required: true)]
+            public ExampleStructure|null $targetValue = null;
+
+            // Without attributes
+            public array|string|int|null $arrayValue = null;
+
+            #[SchemaProperty(anyOf: [Tag::class])]
+            #[ArrayOf(Tag::class, allowEmpty: true)]
+            public array|null $tags;
+        };
+
+        $schema = (new JsonSchema())->generate($class::class);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'currentValue' => [
+                    'type' => ['integer', 'number', 'null'],
+                    'default' => null,
+                    'description' => 'Current value',
+                ],
+                'targetValue' => [
+                    'type' => ['object', 'null'],
+                    'default' => null,
+                    'description' => 'Target value',
+                    'properties' => [
+                        'value' => [
+                            'type' => 'integer',
+                            'description' => 'Value',
+                        ],
+                        'rounded' => [
+                            'type' => 'number',
+                            'description' => 'Rounded',
+                        ],
+                    ],
+                    'additionalProperties' => false,
+                    'required' => ['value'],
+                ],
+                'arrayValue' => [
+                    'type' => ['array', 'string', 'integer', 'null'],
+                    'items' => ['type' => 'string'],
+                    'default' => null,
+                ],
+                'tags' => [
+                    'type' => ['array', 'null'],
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'name' => [
+                                'description' => 'The name of the tag',
+                                'type' => 'string',
+                            ],
+                            'properties' => [
+                                'description' => 'Properties can contains additional values',
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'value' => [
+                                            'description' => 'The property value',
+                                            'type' => 'string',
+                                        ]
+                                    ],
+                                    'additionalProperties' => false,
+                                    'required' => ['value']
+                                ]
+                            ]
+                        ],
+                        'required' => ['name'],
+                        'additionalProperties' => false,
+                    ]
+                ],
+            ],
+            'required' => ['currentValue', 'targetValue'],
             'additionalProperties' => false,
         ], $schema);
     }

--- a/tests/Stubs/StructuredOutput/ExampleStructure.php
+++ b/tests/Stubs/StructuredOutput/ExampleStructure.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\Stubs\StructuredOutput;
+
+use NeuronAI\StructuredOutput\SchemaProperty;
+
+class ExampleStructure
+{
+    #[SchemaProperty(description: "Value")]
+    public int $value;
+
+    #[SchemaProperty(description: "Rounded", required: false)]
+    public float $rounded;
+}

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -655,4 +655,27 @@ class ValidationTest extends TestCase
         $violations = Validator::validate($class);
         $this->assertCount(1, $violations);
     }
+
+    public function test_union_type_validation(): void
+    {
+        $class = new class () {
+            public int|float|string|null $value = null;
+        };
+        $class = new $class();
+
+        $violations = Validator::validate($class);
+        $this->assertCount(0, $violations);
+
+        $class->value = 1;
+        $violations = Validator::validate($class);
+        $this->assertCount(0, $violations);
+
+        $class->value = 1.1;
+        $violations = Validator::validate($class);
+        $this->assertCount(0, $violations);
+
+        $class->value = "one";
+        $violations = Validator::validate($class);
+        $this->assertCount(0, $violations);
+    }
 }


### PR DESCRIPTION
Allows union types to be used with structured output.

Deserializing also checks the data type and tries to cast it to the correct type if it is defined on the structured output class. Behaviour falls back to what was originally there (attempting to cast each type in order).