### PR TITLE
fix(mcp): address security vulnerabilities and compute inefficiencies

### DIFF
--- a/src/MCP/McpClient.php
+++ b/src/MCP/McpClient.php
@@ -143,6 +143,12 @@ class McpClient
 
         $this->transport->send($request);
 
-        return $this->transport->receive();
+        $response = $this->transport->receive();
+
+        if ($response['id'] !== $this->requestId) {
+            throw new McpException('Invalid response ID');
+        }
+
+        return $response;
     }
 }

--- a/src/MCP/SseHttpTransport.php
+++ b/src/MCP/SseHttpTransport.php
@@ -320,7 +320,7 @@ class SseHttpTransport implements McpTransportInterface
                     // Only process 'message' events for JSON-RPC responses
                     if ($parsed['event'] === 'message' && $parsed['data'] !== '') {
                         try {
-                            $message = json_decode($parsed['data'], true, 512, JSON_THROW_ON_ERROR);
+                            $message = json_decode($parsed['data'], true, 32, JSON_THROW_ON_ERROR);
 
                             // Check if it's a valid JSON-RPC message with an ID (response)
                             if (isset($message['jsonrpc']) && $message['jsonrpc'] === '2.0') {
@@ -398,7 +398,7 @@ class SseHttpTransport implements McpTransportInterface
     {
         $headerLines = [];
         foreach ($headers as $key => $value) {
-            $headerLines[] = "$key: $value";
+            $headerLines[] = str_replace(["\r", "\n"], '', $key) . ': ' . str_replace(["\r", "\n"], '', $value);
         }
         return implode("\r\n", $headerLines) . "\r\n";
     }
@@ -408,8 +408,13 @@ class SseHttpTransport implements McpTransportInterface
      */
     protected function resolveEndpointUrl(string $base, string $relative): string
     {
-        // If relative is absolute URL, return it
+        // If relative is absolute URL, validate it stays on the same host to prevent SSRF
         if (str_contains($relative, '://') || str_starts_with($relative, '//')) {
+            $baseParts = parse_url($base);
+            $relativeParts = parse_url($relative);
+            if ($baseParts === false || $relativeParts === false || ($relativeParts['host'] ?? '') !== ($baseParts['host'] ?? '')) {
+                throw new McpException('Endpoint URL host mismatch: cross-origin redirect rejected');
+            }
             return $relative;
         }
 

--- a/src/MCP/StdioTransport.php
+++ b/src/MCP/StdioTransport.php
@@ -24,7 +24,7 @@ use function stream_set_blocking;
 use function stream_set_read_buffer;
 use function stream_set_write_buffer;
 use function mb_strlen;
-use function time;
+use function microtime;
 use function usleep;
 
 class StdioTransport implements McpTransportInterface
@@ -143,11 +143,10 @@ class StdioTransport implements McpTransportInterface
         stream_set_blocking($this->pipes[1], false);
 
         $response = "";
-        $startTime = time();
-        $timeout = 30; // 30-second timeout
+        $deadline = microtime(true) + ($this->config['timeout'] ?? 30);
 
         // Keep reading until we get a complete JSON response or timeout
-        while (time() - $startTime < $timeout) {
+        while (microtime(true) < $deadline) {
             $status = proc_get_status($this->process);
 
             if (!$status['running']) {

--- a/src/MCP/StreamableHttpTransport.php
+++ b/src/MCP/StreamableHttpTransport.php
@@ -136,7 +136,7 @@ class StreamableHttpTransport implements McpTransportInterface
             }
 
             try {
-                return json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+                return json_decode($response, true, 32, JSON_THROW_ON_ERROR);
             } catch (JsonException $e) {
                 // If the response from the server is not a valid JSON
                 // try to parse the SSE format to extract JSON data

--- a/tests/MCP/McpConnectorTest.php
+++ b/tests/MCP/McpConnectorTest.php
@@ -260,7 +260,7 @@ class McpConnectorTest extends TestCase
             extraResponses: [
                 [
                 'jsonrpc' => '2.0',
-                'id' => 3,
+                'id' => 2,
                 'result' => [
                     'content' => [
                         ['type' => 'text', 'text' => 'The result is 42'],


### PR DESCRIPTION
- SSRF: validate absolute endpoint URLs from SSE server stay on same host
- Header injection: strip CR/LF from header keys and values in buildHeaderString
- Response ID: enforce ID validation in callTool (was only done in listTools)
- Timeout precision: replace time() with microtime(true) in StdioTransport::receive
- JSON depth: reduce decode depth from 512 to 32 to limit nested-payload amplification
- Test: correct pre-existing wrong response ID fixture (3→2) in McpConnectorTest

https://claude.ai/code/session_01TPCdk4CYcjHneAxZUEjXuZ