### PR TITLE
Set response in HttpException when available

### DIFF
--- a/src/HttpClient/GuzzleHttpClient.php
+++ b/src/HttpClient/GuzzleHttpClient.php
@@ -6,6 +6,7 @@ namespace NeuronAI\HttpClient;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\RequestOptions;
 use NeuronAI\Exceptions\HttpException;
@@ -53,7 +54,7 @@ class GuzzleHttpClient implements HttpClientInterface
                 headers: $response->getHeaders(),
             );
         } catch (GuzzleException $e) {
-            throw HttpException::networkError($request, $e);
+            $this->handleException($request, $e);
         }
     }
 
@@ -73,7 +74,7 @@ class GuzzleHttpClient implements HttpClientInterface
 
             return new GuzzleStream($response->getBody());
         } catch (GuzzleException $e) {
-            throw HttpException::networkError($request, $e);
+            $this->handleException($request, $e);
         }
     }
 
@@ -196,5 +197,23 @@ class GuzzleHttpClient implements HttpClientInterface
             : $request->uri;
 
         return $client->request($request->method->value, $uri, $options);
+    }
+
+    /**
+     * @throws HttpException
+     */
+    protected function handleException(HttpRequest $request, GuzzleException $e): never
+    {
+        if ($e instanceof RequestException && $e->hasResponse()) {
+            $response = new HttpResponse(
+                statusCode: $e->getResponse()->getStatusCode(),
+                body: (string) $e->getResponse()->getBody(),
+                headers: $e->getResponse()->getHeaders(),
+            );
+
+            throw HttpException::httpError($request, $response);
+        }
+
+        throw HttpException::networkError($request, $e);
     }
 }


### PR DESCRIPTION
`$response` is `null` in `HttpException::networkError()`, despite the response _sometimes_ being available under `$e->previous`. 

```php
if ($e->previous instanceof \GuzzleHttp\Exception\RequestException) {
  $e->previous->getResponse()->getStatusCode();
}
```

But then other times you catch `\NeuronAI\Exceptions\HttpException` the `$response` property is available. This results in difficult to maintain code, where you've got to check both `$e->previous` and `$e->response` to determine what the response was.

I think it makes sense to provide the guzzle response in this scenario.