### PR TITLE
Extend NeuronException in HttpException

### DIFF
--- a/src/Exceptions/HttpException.php
+++ b/src/Exceptions/HttpException.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NeuronAI\Exceptions;
 
-use Exception;
 use GuzzleHttp\Exception\RequestException;
 use NeuronAI\HttpClient\HttpRequest;
 use NeuronAI\HttpClient\HttpResponse;
@@ -13,7 +12,7 @@ use Throwable;
 /**
  * Exception thrown when HTTP request fails.
  */
-class HttpException extends Exception
+class HttpException extends NeuronException
 {
     public function __construct(
         string $message,


### PR DESCRIPTION
Is `HttpException` deliberately the only exception class not to extend `NeuronException`?