### PR TITLE
Fix property validation incorrectly rejects null on nullable properties

### DIFF
--- a/src/StructuredOutput/Validation/Rules/Enum.php
+++ b/src/StructuredOutput/Validation/Rules/Enum.php
@@ -22,12 +22,14 @@ class Enum extends AbstractValidationRule
     /**
      * @param array|null $values List of allowed values. Cannot be used with `enum`.
      * @param string|null $class Enum class name to extract choices from. Cannot be used with `choices`.
+     * @param bool $nullable Whether null is a valid value.
      *
      * @throws StructuredOutputException if both `choices` and `enum` are provided or if `enum` is not valid.
      */
     public function __construct(
         protected ?array  $values = [],
         protected ?string $class = null,
+        protected bool    $nullable = false,
     ) {
         if ($this->values !== null && $this->values !== [] && $this->class !== null) {
             throw new StructuredOutputException('You cannot provide both "choices" and "enum" options simultaneously. Please use only one.');
@@ -45,6 +47,9 @@ class Enum extends AbstractValidationRule
     public function validate(string $name, mixed $value, array &$violations): void
     {
         if ($value === null) {
+            if (!$this->nullable) {
+                $violations[] = $this->buildMessage($name, $this->message, ['choices' => implode(", ", $this->values)]);
+            }
             return;
         }
 

--- a/src/StructuredOutput/Validation/Rules/Enum.php
+++ b/src/StructuredOutput/Validation/Rules/Enum.php
@@ -44,6 +44,10 @@ class Enum extends AbstractValidationRule
 
     public function validate(string $name, mixed $value, array &$violations): void
     {
+        if ($value === null) {
+            return;
+        }
+
         $value = $value instanceof BackedEnum ? $value->value : $value;
 
         if (!in_array($value, $this->values, true)) {

--- a/src/StructuredOutput/Validation/Validator.php
+++ b/src/StructuredOutput/Validation/Validator.php
@@ -6,7 +6,6 @@ namespace NeuronAI\StructuredOutput\Validation;
 
 use ReflectionClass;
 use ReflectionException;
-use ReflectionNamedType;
 use ReflectionProperty;
 
 class Validator
@@ -33,11 +32,6 @@ class Validator
             // Get the value of the property
             $name = $property->getName();
             $value = $property->isInitialized($obj) ? $property->getValue($obj) : null;
-
-            $type = $property->getType();
-            if ($value === null && $type instanceof ReflectionNamedType && $type->allowsNull()) {
-                continue;
-            }
 
             // Apply all the validation rules to the value
             foreach ($attributes as $attribute) {

--- a/src/StructuredOutput/Validation/Validator.php
+++ b/src/StructuredOutput/Validation/Validator.php
@@ -6,6 +6,7 @@ namespace NeuronAI\StructuredOutput\Validation;
 
 use ReflectionClass;
 use ReflectionException;
+use ReflectionNamedType;
 use ReflectionProperty;
 
 class Validator
@@ -32,6 +33,11 @@ class Validator
             // Get the value of the property
             $name = $property->getName();
             $value = $property->isInitialized($obj) ? $property->getValue($obj) : null;
+
+            $type = $property->getType();
+            if ($value === null && $type instanceof ReflectionNamedType && $type->allowsNull()) {
+                continue;
+            }
 
             // Apply all the validation rules to the value
             foreach ($attributes as $attribute) {

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -570,7 +570,7 @@ class ValidationTest extends TestCase
         $this->assertCount(0, $violations);
     }
 
-public function test_enum_validation_exception_both_option_provided(): void
+    public function test_enum_validation_exception_both_option_provided(): void
     {
         $class = new class () {
             #[Enum(values: ['one', 'two', 'three'], class: StringEnum::class)]

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -554,7 +554,23 @@ class ValidationTest extends TestCase
         // $obj->intEnum = 3; -> TypeError anyway...
     }
 
-    public function test_enum_validation_exception_both_option_provided(): void
+    public function test_enum_validation_nullable_allows_null(): void
+    {
+        $class = new class () {
+            #[Enum(values: ['one', 'two', 'three'])]
+            public ?string $number = null;
+
+            #[Enum(class: StringEnum::class)]
+            public ?string $enumNumber = null;
+        };
+
+        $obj = new $class();
+
+        $violations = Validator::validate($obj);
+        $this->assertCount(0, $violations);
+    }
+
+public function test_enum_validation_exception_both_option_provided(): void
     {
         $class = new class () {
             #[Enum(values: ['one', 'two', 'three'], class: StringEnum::class)]

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -557,10 +557,10 @@ class ValidationTest extends TestCase
     public function test_enum_validation_nullable_allows_null(): void
     {
         $class = new class () {
-            #[Enum(values: ['one', 'two', 'three'])]
+            #[Enum(values: ['one', 'two', 'three'], nullable: true)]
             public ?string $number = null;
 
-            #[Enum(class: StringEnum::class)]
+            #[Enum(class: StringEnum::class, nullable: true)]
             public ?string $enumNumber = null;
         };
 
@@ -568,6 +568,14 @@ class ValidationTest extends TestCase
 
         $violations = Validator::validate($obj);
         $this->assertCount(0, $violations);
+    }
+
+    public function test_enum_validation_non_nullable_rejects_null(): void
+    {
+        $rule = new Enum(values: ['one', 'two', 'three']);
+        $violations = [];
+        $rule->validate('number', null, $violations);
+        $this->assertCount(1, $violations);
     }
 
     public function test_enum_validation_exception_both_option_provided(): void


### PR DESCRIPTION
I have a class with:
```php
    #[SchemaProperty(
        description: 'The category that best describes the reason for escalation. Choose from the predefined categories based on the conversation context.',
    )]
    #[Enum(class: EscalationCategory::class)]
    public ?EscalationCategory $category = null;
```

It's failing validation because the LLM returned `null`:
```
structured-validated {
  "class":"...",
  "json":"{\"handoff\":false,\"reason\":\"...\",\"category\":null,\"handoff_message_unauthenticated\":\"\",\"handoff_message\":\"\"}",
  "violations": [
    "category must be one of the following allowed values: a, b, c."
  ]
}
```

This PR makes changes so that `null` is permitted on `nullable` properties. Validation rules will be skipped