### PR TITLE
Fix filter string formatting in deleteBy method

### DIFF
--- a/src/RAG/VectorStore/MeilisearchVectorStore.php
+++ b/src/RAG/VectorStore/MeilisearchVectorStore.php
@@ -105,8 +105,8 @@ class MeilisearchVectorStore implements VectorStoreInterface
     public function deleteBy(string $sourceType, ?string $sourceName = null): VectorStoreInterface
     {
         $filter = $sourceName !== null
-            ? "sourceType = {$sourceType} AND sourceName = '{$sourceName}'"
-            : "sourceType = {$sourceType}";
+            ? "sourceType = '{$sourceType}' AND sourceName = '{$sourceName}'"
+            : "sourceType = '{$sourceType}'";
 
         $this->httpClient->request(
             HttpRequest::post(


### PR DESCRIPTION
I think these should be escaped like the `sourceName`? Otherwise you get:
```
Found unexpected characters at the end of the filter: `:bar AND sourceName = \\'85480\\'`. You probably forgot an `OR` or an `AND` rule. 
```

`sourceName` is set to `foo:bar`