### PR TITLE
fix(bedrock): wrap streamed text deltas in TextContent before updateContentBlock()

### DIFF
--- a/src/Providers/AWS/HandleStream.php
+++ b/src/Providers/AWS/HandleStream.php
@@ -64,7 +64,10 @@ trait HandleStream
 
                 if (isset($event['contentBlockDelta']['delta']['text'])) {
                     $textChunk = $event['contentBlockDelta']['delta']['text'];
-                    $this->streamState->updateContentBlock($event['contentBlockDelta']['contentBlockIndex'], $textChunk);
+                    $this->streamState->updateContentBlock(
+                        $event['contentBlockDelta']['contentBlockIndex'],
+                        new \NeuronAI\Chat\Messages\ContentBlocks\TextContent($textChunk)
+                    );
                     yield new TextChunk($this->streamState->messageId(), $textChunk);
                 }
 


### PR DESCRIPTION
### Problem

`src/Providers/AWS/HandleStream.php` passes the raw delta **string** to `StreamState::updateContentBlock(int $index, ContentBlockInterface $block)`:

```php
if (isset($event['contentBlockDelta']['delta']['text'])) {
    $textChunk = $event['contentBlockDelta']['delta']['text'];
    $this->streamState->updateContentBlock($event['contentBlockDelta']['contentBlockIndex'], $textChunk);
    yield new TextChunk($this->streamState->messageId(), $textChunk);
}
```

Since `declare(strict_types=1)` was added to this file, this is a runtime `TypeError` on every Bedrock ConverseStream response that contains a text block — i.e. any streamed text completion via the Bedrock provider:

```
TypeError: StreamState::updateContentBlock(): Argument #2 ($block) must be of type ContentBlockInterface, string given
```

The adjacent `reasoningContent` branch already handles this correctly (wraps the delta in `ReasoningContent` before calling `updateContentBlock`); the text branch never got the same treatment.

### Fix

Mirror the reasoning-branch pattern for text deltas by wrapping the chunk in `TextContent`.

### Reproduction

Any `stream()` call through `BedrockRuntime` against a Converse-compatible model that returns text.

### Context

We have carried this as a downstream composer patch since v3.3.10, where the same line produced a malformed content-block shape that dropped `tool_use` blocks; `strict_types` has since upgraded it from silent corruption to a hard crash. Happy to adjust style (e.g. import `TextContent` instead of the FQCN) if preferred.
