### PR TITLE
fix(anthropic): omit null system field in streaming payload (parity with chat)

### DIFF
--- a/src/Providers/Anthropic/HandleStream.php
+++ b/src/Providers/Anthropic/HandleStream.php
@@ -36,7 +36,7 @@ trait HandleStream
             'stream' => true,
             'model' => $this->model,
             'max_tokens' => $this->max_tokens,
-            'system' => $this->system ?? null,
+            ...($this->system !== null ? ['system' => $this->system] : []),
             'messages' => $this->messageMapper()->map($messages),
             ...$this->parameters,
         ];


### PR DESCRIPTION
### Problem

`HandleChat` sets `system` conditionally, but the Anthropic streaming path still sends the field unconditionally — `src/Providers/Anthropic/HandleStream.php`:

```php
'system' => $this->system ?? null,
```

`GuzzleHttpClient::runRequest` passes the body verbatim via `RequestOptions::JSON`, so an agent with no system prompt sends `"system": null`, which the Anthropic Messages API rejects with a validation error. Streaming without a system prompt is therefore impossible on the Anthropic provider.

### Fix

Mirror the chat path's conditional:

```php
...($this->system !== null ? ['system' => $this->system] : []),
```

A possible follow-up (happy to include here if you'd like): the stream path also ignores `systemPromptBlocks`, while chat now has a `systemBlocks` branch — mirroring that would give streaming full parity with chat for prompt-caching users.

### Reproduction

Call `stream()` on an Anthropic agent with no system prompt and inspect the outgoing request payload / API error response.

### Context

Carried as a downstream composer patch since v3.3.10; applies cleanly to current `3.x`.
