### PR TITLE
Merge raw JSON schema parameters in OpenAI Responses ToolMapper

### DIFF
--- a/src/Providers/OpenAI/Responses/ToolMapper.php
+++ b/src/Providers/OpenAI/Responses/ToolMapper.php
@@ -11,6 +11,7 @@ use NeuronAI\Tools\ToolInterface;
 use NeuronAI\Tools\ToolPropertyInterface;
 use stdClass;
 
+use function array_merge;
 use function array_reduce;
 use function is_string;
 
@@ -58,6 +59,10 @@ class ToolMapper implements ToolMapperInterface
                 'properties' => $properties,
                 'required' => $tool->getRequiredProperties(),
             ];
+        }
+
+        if ($tool->getParameters() !== []) {
+            $payload = array_merge($payload, $tool->getParameters());
         }
 
         return $payload;

--- a/tests/Providers/OpenAIResponsesToolMapperTest.php
+++ b/tests/Providers/OpenAIResponsesToolMapperTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\Providers;
+
+use NeuronAI\Providers\OpenAI\Responses\ToolMapper;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use PHPUnit\Framework\TestCase;
+
+class OpenAIResponsesToolMapperTest extends TestCase
+{
+    public function test_tool_with_raw_parameters(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'sku' => ['type' => 'string', 'description' => 'The product SKU'],
+            ],
+            'required' => ['sku'],
+        ];
+
+        $tool = Tool::make('get_stock', 'Get the current stock level for a SKU.')
+            ->setParameters(['parameters' => $schema]);
+
+        $mapping = (new ToolMapper())->map([$tool]);
+
+        $this->assertSame([
+            [
+                'type' => 'function',
+                'name' => 'get_stock',
+                'description' => 'Get the current stock level for a SKU.',
+                'parameters' => $schema,
+            ],
+        ], $mapping);
+    }
+
+    public function test_tool_with_properties(): void
+    {
+        $tool = Tool::make('get_stock', 'Get the current stock level for a SKU.')
+            ->addProperty(new ToolProperty('sku', PropertyType::STRING, 'The product SKU', true));
+
+        $mapping = (new ToolMapper())->map([$tool]);
+
+        $this->assertSame([
+            [
+                'type' => 'function',
+                'name' => 'get_stock',
+                'description' => 'Get the current stock level for a SKU.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'sku' => ['type' => 'string', 'description' => 'The product SKU'],
+                    ],
+                    'required' => ['sku'],
+                ],
+            ],
+        ], $mapping);
+    }
+}


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Description

### What does this PR do?

`NeuronAI\Providers\OpenAI\Responses\ToolMapper::mapTool()` now merges `Tool::getParameters()` (the raw JSON schema path) into the tool payload, exactly like the Chat Completions mapper (`NeuronAI\Providers\OpenAI\ToolMapper`) already does. The merge happens top-level instead of under `function`, matching the Responses wire format where the function fields are flat.

### Why is this change needed?

Tools defined via `Tool::make(...)->setParameters([...])` (raw JSON schema instead of `ToolProperty` objects) are currently sent to `/v1/responses` with **empty** `parameters`:

```php
Tool::make('get_stock', 'Get the stock level for a SKU.')
    ->setParameters(['parameters' => [
        'type' => 'object',
        'properties' => ['sku' => ['type' => 'string']],
        'required' => ['sku'],
    ]]);
```

goes over the wire as

```json
{"type":"function","name":"get_stock","description":"...","parameters":{"type":"object","properties":{},"required":[]}}
```

so the model cannot pass any arguments — every call arrives with empty inputs. Verified empirically against both `https://api.openai.com/v1/responses` (gpt-5.x) and `https://api.x.ai/v1/responses` (grok-4.x, via `OpenAILikeResponses`): with this fix the schema is transmitted and tool calls arrive with correct arguments; the same tool definition already works on the Chat Completions path, which has the equivalent merge branch in its `ToolMapper`.

### How does this change should be used and documented?

No usage change — `setParameters()` simply behaves on the Responses path the same way it already behaves on the Chat Completions path. No documentation change needed.

## Related Issues

-

## Testing

- [x] I have tested this change locally (real requests against OpenAI and xAI Responses endpoints: tool schema is transmitted, tool calls arrive with populated arguments, both `chat()` and `stream()`)
- [x] I have added/updated unit tests where appropriate (`tests/Providers/OpenAIResponsesToolMapperTest.php`: raw-schema path and `ToolProperty` path)
- [x] All existing tests pass (1187 tests, 75 pre-existing skips)
- [ ] I have tested this with different PHP versions (if applicable) — PHP 8.3 only

## Breaking Changes

- [x] No breaking changes

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] My code follows the project's coding standards (PHPStan) — `composer analyse` passes
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] My commit messages are clear and descriptive
- [x] This PR addresses only ONE specific goal/issue

## Additional Notes

Like the Completions mapper, the merge intentionally lets a raw schema override the `ToolProperty`-derived `parameters` when both are set, keeping the two mappers consistent.