### PR TITLE
Add withFilters to Qdrant and Meilisearch

### DIFF
--- a/src/RAG/VectorStore/MeilisearchVectorStore.php
+++ b/src/RAG/VectorStore/MeilisearchVectorStore.php
@@ -26,6 +26,15 @@ class MeilisearchVectorStore implements VectorStoreInterface
     use HasHttpClient;
 
     /**
+     * Native Meilisearch filter expressions applied to similaritySearch().
+     *
+     * https://www.meilisearch.com/docs/reference/api/search#filter
+     *
+     * @var array<int, mixed>
+     */
+    protected array $filters = [];
+
+    /**
      * @throws HttpException
      */
     public function __construct(
@@ -119,23 +128,38 @@ class MeilisearchVectorStore implements VectorStoreInterface
     }
 
     /**
+     * @param  array<int, mixed>  $filters  Native Meilisearch filter expressions.
+     */
+    public function withFilters(array $filters): self
+    {
+        $this->filters = $filters;
+        return $this;
+    }
+
+    /**
      * @throws HttpException
      */
     public function similaritySearch(array $embedding): iterable
     {
+        $body = [
+            'vector' => $embedding,
+            'limit' => min($this->topK, 20),
+            'retrieveVectors' => true,
+            'showRankingScore' => true,
+            'hybrid' => [
+                'semanticRatio' => 1.0,
+                'embedder' => $this->embedder,
+            ],
+        ];
+
+        if ($this->filters !== []) {
+            $body['filter'] = $this->filters;
+        }
+
         $response = $this->httpClient->request(
             HttpRequest::post(
                 uri: "/indexes/{$this->indexUid}/search",
-                body: [
-                    'vector' => $embedding,
-                    'limit' => min($this->topK, 20),
-                    'retrieveVectors' => true,
-                    'showRankingScore' => true,
-                    'hybrid' => [
-                        'semanticRatio' => 1.0,
-                        'embedder' => $this->embedder,
-                    ],
-                ]
+                body: $body
             )
         )->json();
 

--- a/src/RAG/VectorStore/QdrantVectorStore.php
+++ b/src/RAG/VectorStore/QdrantVectorStore.php
@@ -21,6 +21,15 @@ class QdrantVectorStore implements VectorStoreInterface
     use HasHttpClient;
 
     /**
+     * Qdrant "must" filter conditions applied to similaritySearch().
+     *
+     * https://qdrant.tech/documentation/concepts/filtering/
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    protected array $filters = [];
+
+    /**
      * @throws HttpException
      */
     public function __construct(
@@ -143,21 +152,36 @@ class QdrantVectorStore implements VectorStoreInterface
     }
 
     /**
+     * @param  array<int, array<string, mixed>>  $filters  Qdrant "must" filter conditions.
+     */
+    public function withFilters(array $filters): self
+    {
+        $this->filters = $filters;
+        return $this;
+    }
+
+    /**
      * @throws HttpException
      */
     public function similaritySearch(array $embedding): iterable
     {
+        $body = [
+            'query' => [
+                'recommend' => ['positive' => [$embedding]],
+            ],
+            'limit' => $this->topK,
+            'with_payload' => true,
+            'with_vector' => true,
+        ];
+
+        if ($this->filters !== []) {
+            $body['filter'] = ['must' => $this->filters];
+        }
+
         $response = $this->httpClient->request(
             HttpRequest::post(
                 uri: 'points/query',
-                body: [
-                    'query' => [
-                        'recommend' => ['positive' => [$embedding]],
-                    ],
-                    'limit' => $this->topK,
-                    'with_payload' => true,
-                    'with_vector' => true,
-                ]
+                body: $body
             )
         )->json();
 

--- a/tests/VectorStore/MeiliSearchTest.php
+++ b/tests/VectorStore/MeiliSearchTest.php
@@ -126,4 +126,30 @@ class MeiliSearchTest extends TestCase
         $this->assertEquals('file', $results[0]->getSourceType());
         $this->assertEquals('Hello type B!', $results[0]->getContent());
     }
+
+    public function test_similarity_search_with_filters(): void
+    {
+        $store = new MeilisearchVectorStore('neuron');
+
+        $document1 = new Document('Hello type A!');
+        $document1->embedding = $this->embedding;
+        $document1->sourceType = 'web';
+        $document1->sourceName = 'page-a';
+
+        $document2 = new Document('Hello type B!');
+        $document2->embedding = $this->embedding;
+        $document2->sourceType = 'file';
+        $document2->sourceName = 'doc.txt';
+
+        $store->addDocuments([$document1, $document2]);
+
+        // Wait for Meilisearch to index the documents
+        sleep(5);
+
+        $store->withFilters(["sourceType = 'file'"]);
+        $results = $store->similaritySearch($this->embedding);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('file', $results[0]->getSourceType());
+    }
 }

--- a/tests/VectorStore/QdrantTest.php
+++ b/tests/VectorStore/QdrantTest.php
@@ -130,4 +130,30 @@ class QdrantTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertEquals('file', $results[0]->getSourceType());
     }
+
+    /**
+     * @throws GuzzleException
+     */
+    public function test_similarity_search_with_filters(): void
+    {
+        $document1 = new Document('Hello type A!');
+        $document1->sourceType = 'web';
+        $document1->sourceName = 'page-a';
+        $document1->embedding = [1, 2, 3];
+
+        $document2 = new Document('Hello type B!');
+        $document2->sourceType = 'file';
+        $document2->sourceName = 'doc.txt';
+        $document2->embedding = [1, 2, 3];
+
+        $this->store->addDocuments([$document1, $document2]);
+        $this->store->withFilters([
+            ['key' => 'sourceType', 'match' => ['value' => 'file']],
+        ]);
+
+        $results = $this->store->similaritySearch([1, 2, 3]);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('file', $results[0]->getSourceType());
+    }
 }


### PR DESCRIPTION
Elasticsearch, OpenSearch, and Pinecone all have a `withFilters` function that allows you to add filters to the `similaritySearch()` call. This PR copies that behaviour to the Qdrant and Meilisearch vector stores.

I can send another PR with the other vectors updated if you want, or update this PR (but it's a larger change log)?

