### PR TITLE
Content from tools

### DIFF
--- a/src/Chat/History/AbstractChatHistory.php
+++ b/src/Chat/History/AbstractChatHistory.php
@@ -23,6 +23,7 @@ use NeuronAI\Chat\Messages\Usage;
 use NeuronAI\Chat\Messages\UserMessage;
 use NeuronAI\Exceptions\ChatHistoryException;
 use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolOutput;
 
 use function array_map;
 use function count;
@@ -195,10 +196,26 @@ abstract class AbstractChatHistory implements ChatHistoryInterface
      */
     protected function deserializeToolCallResult(array $message): ToolResultMessage
     {
-        $tools = array_map(fn (array $tool) => Tool::make($tool['name'], $tool['description'])
-            ->setInputs($tool['inputs'])
-            ->setCallId($tool['callId'])
-            ->setResult($tool['result']), $message['tools']);
+        $tools = array_map(function (array $tool): Tool {
+            $toolInstance = Tool::make($tool['name'], $tool['description'])
+                ->setInputs($tool['inputs'])
+                ->setCallId($tool['callId']);
+
+            if (isset($tool['resultOutput']) && is_array($tool['resultOutput']) && isset($tool['resultOutput']['blocks']) && $tool['resultOutput']['blocks'] !== []) {
+                $blocks = array_map(
+                    $this->deserializeContentBlock(...),
+                    $tool['resultOutput']['blocks']
+                );
+                $toolInstance->setResult(new ToolOutput(
+                    text: $tool['resultOutput']['text'] ?? null,
+                    blocks: $blocks,
+                ));
+            } else {
+                $toolInstance->setResult($tool['result']);
+            }
+
+            return $toolInstance;
+        }, $message['tools']);
 
         return new ToolResultMessage($tools);
     }

--- a/src/Chat/Messages/ToolResultMessage.php
+++ b/src/Chat/Messages/ToolResultMessage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeuronAI\Chat\Messages;
 
+use NeuronAI\Tools\HasOutput;
 use NeuronAI\Tools\ToolInterface;
 use Stringable;
 
@@ -38,7 +39,13 @@ class ToolResultMessage extends UserMessage implements Stringable
             parent::jsonSerialize(),
             [
                 'type' => 'tool_call_result',
-                'tools' => array_map(fn (ToolInterface $tool): array => $tool->jsonSerialize(), $this->tools),
+                'tools' => array_map(function (ToolInterface $tool): array {
+                    $data = $tool->jsonSerialize();
+                    if ($tool instanceof HasOutput && $tool->getOutput()->hasBlocks()) {
+                        unset($data['result']);
+                    }
+                    return $data;
+                }, $this->tools),
             ]
         );
     }

--- a/src/Providers/AWS/MessageMapper.php
+++ b/src/Providers/AWS/MessageMapper.php
@@ -19,6 +19,7 @@ use NeuronAI\Chat\Messages\ToolResultMessage;
 use NeuronAI\Chat\Messages\UserMessage;
 use NeuronAI\Exceptions\ProviderException;
 use NeuronAI\Providers\MessageMapperInterface;
+use NeuronAI\Tools\HasOutput;
 use stdClass;
 
 use function array_map;
@@ -57,15 +58,13 @@ class MessageMapper implements MessageMapperInterface
     {
         $toolContents = [];
         foreach ($message->getTools() as $tool) {
+            $content = ($tool instanceof HasOutput && $tool->getOutput()->hasBlocks())
+                ? $this->mapBlocks($tool->getOutput()->getBlocks())
+                : [['json' => ['result' => $tool->getResult()]]];
+
             $toolContents[] = [
                 'toolResult' => [
-                    'content' => [
-                        [
-                            'json' => [
-                                'result' => $tool->getResult(),
-                            ],
-                        ],
-                    ],
+                    'content' => $content,
                     'toolUseId' => $tool->getCallId(),
                 ],
             ];

--- a/src/Providers/Anthropic/MessageMapper.php
+++ b/src/Providers/Anthropic/MessageMapper.php
@@ -18,6 +18,7 @@ use NeuronAI\Chat\Messages\ToolResultMessage;
 use NeuronAI\Chat\Messages\UserMessage;
 use NeuronAI\Exceptions\ProviderException;
 use NeuronAI\Providers\MessageMapperInterface;
+use NeuronAI\Tools\HasOutput;
 use NeuronAI\Tools\ToolInterface;
 use stdClass;
 
@@ -159,11 +160,17 @@ class MessageMapper implements MessageMapperInterface
 
     protected function mapToolsResult(ToolResultMessage $message): array
     {
-        $parts = array_map(fn (ToolInterface $tool): array => [
-            'type' => 'tool_result',
-            'tool_use_id' => $tool->getCallId(),
-            'content' => $tool->getResult(),
-        ], $message->getTools());
+        $parts = array_map(function (ToolInterface $tool): array {
+            $content = ($tool instanceof HasOutput && $tool->getOutput()->hasBlocks())
+                ? $this->mapBlocks($tool->getOutput()->getBlocks())
+                : $tool->getResult();
+
+            return [
+                'type' => 'tool_result',
+                'tool_use_id' => $tool->getCallId(),
+                'content' => $content,
+            ];
+        }, $message->getTools());
 
         if ($contentBlocks = $message->getContentBlocks()) {
             $parts = [...$parts, ...$this->mapBlocks($contentBlocks)];

--- a/src/Providers/Gemini/MessageMapper.php
+++ b/src/Providers/Gemini/MessageMapper.php
@@ -20,6 +20,7 @@ use NeuronAI\Chat\Messages\ToolResultMessage;
 use NeuronAI\Chat\Messages\UserMessage;
 use NeuronAI\Exceptions\ProviderException;
 use NeuronAI\Providers\MessageMapperInterface;
+use NeuronAI\Tools\HasOutput;
 use NeuronAI\Tools\ToolInterface;
 use stdClass;
 
@@ -137,15 +138,22 @@ class MessageMapper implements MessageMapperInterface
 
     protected function mapToolsResult(ToolResultMessage $message): array
     {
-        $parts = array_map(fn (ToolInterface $tool): array => [
-            'functionResponse' => [
-                'name' => $tool->getName(),
-                'response' => [
+        $parts = array_map(function (ToolInterface $tool): array {
+            $response = ['name' => $tool->getName()];
+
+            if ($tool instanceof HasOutput && $tool->getOutput()->hasBlocks()) {
+                $response['content'] = ['parts' => $this->mapBlocks($tool->getOutput()->getBlocks())];
+            } else {
+                $response['content'] = $tool->getResult();
+            }
+
+            return [
+                'functionResponse' => [
                     'name' => $tool->getName(),
-                    'content' => $tool->getResult(),
+                    'response' => $response,
                 ],
-            ],
-        ], $message->getTools());
+            ];
+        }, $message->getTools());
 
         if ($contentBlocks = $message->getContentBlocks()) {
             $parts = [...$parts, ...$this->mapBlocks($contentBlocks)];

--- a/src/Providers/Mistral/MessageMapper.php
+++ b/src/Providers/Mistral/MessageMapper.php
@@ -19,6 +19,7 @@ use NeuronAI\Chat\Messages\ToolResultMessage;
 use NeuronAI\Chat\Messages\UserMessage;
 use NeuronAI\Exceptions\ProviderException;
 use NeuronAI\Providers\MessageMapperInterface;
+use NeuronAI\Tools\HasOutput;
 use NeuronAI\Tools\ToolInterface;
 use stdClass;
 
@@ -145,10 +146,14 @@ class MessageMapper implements MessageMapperInterface
     protected function mapToolsResult(ToolResultMessage $message): void
     {
         foreach ($message->getTools() as $tool) {
+            $content = ($tool instanceof HasOutput && $tool->getOutput()->hasBlocks())
+                ? $this->mapBlocks($tool->getOutput()->getBlocks())
+                : $tool->getResult();
+
             $this->mapping[] = [
                 'role' => MessageRole::TOOL,
                 'tool_call_id' => $tool->getCallId(),
-                'content' => $tool->getResult(),
+                'content' => $content,
             ];
         }
     }

--- a/src/Providers/OpenAI/MessageMapper.php
+++ b/src/Providers/OpenAI/MessageMapper.php
@@ -17,6 +17,7 @@ use NeuronAI\Chat\Messages\ToolResultMessage;
 use NeuronAI\Chat\Messages\UserMessage;
 use NeuronAI\Exceptions\ProviderException;
 use NeuronAI\Providers\MessageMapperInterface;
+use NeuronAI\Tools\HasOutput;
 use NeuronAI\Tools\ToolInterface;
 use stdClass;
 
@@ -138,10 +139,16 @@ class MessageMapper implements MessageMapperInterface
 
     protected function mapToolsResult(ToolResultMessage $message): array
     {
-        return array_map(fn (ToolInterface $tool): array => [
-            'role' => MessageRole::TOOL,
-            'tool_call_id' => $tool->getCallId(),
-            'content' => $tool->getResult(),
-        ], $message->getTools());
+        return array_map(function (ToolInterface $tool): array {
+            $content = ($tool instanceof HasOutput && $tool->getOutput()->hasBlocks())
+                ? $this->mapBlocks($tool->getOutput()->getBlocks())
+                : $tool->getResult();
+
+            return [
+                'role' => MessageRole::TOOL,
+                'tool_call_id' => $tool->getCallId(),
+                'content' => $content,
+            ];
+        }, $message->getTools());
     }
 }

--- a/src/Providers/OpenAI/Responses/MessageMapper.php
+++ b/src/Providers/OpenAI/Responses/MessageMapper.php
@@ -17,6 +17,7 @@ use NeuronAI\Chat\Messages\ToolResultMessage;
 use NeuronAI\Chat\Messages\UserMessage;
 use NeuronAI\Exceptions\ProviderException;
 use NeuronAI\Providers\MessageMapperInterface;
+use NeuronAI\Tools\HasOutput;
 use stdClass;
 
 use function array_filter;
@@ -155,10 +156,14 @@ class MessageMapper implements MessageMapperInterface
     protected function mapToolsResult(ToolResultMessage $message): void
     {
         foreach ($message->getTools() as $tool) {
+            $output = ($tool instanceof HasOutput && $tool->getOutput()->hasBlocks())
+                ? $this->mapBlocks($tool->getOutput()->getBlocks(), true)
+                : $tool->getResult();
+
             $this->mapping[] = [
                 'type' => 'function_call_output',
                 'call_id' => $tool->getCallId(),
-                'output' => $tool->getResult(),
+                'output' => $output,
             ];
         }
     }

--- a/src/RAG/VectorStore/FileVectorStore.php
+++ b/src/RAG/VectorStore/FileVectorStore.php
@@ -88,7 +88,7 @@ class FileVectorStore implements VectorStoreInterface
                 $matchesType = $document['sourceType'] === $sourceType;
                 $matchesName = $sourceName === null || $document['sourceName'] === $sourceName;
 
-                if (!($matchesType && $matchesName)) {
+                if (!$matchesType || !$matchesName) {
                     fwrite($tempHandle, (string) $line);
                 }
             }

--- a/src/Tools/AGENTS.md
+++ b/src/Tools/AGENTS.md
@@ -8,8 +8,64 @@ Tool system for agent capabilities. Tools are callable functions exposed to AI.
 |------|---------|
 | `ToolInterface.php` | Contract: `getName()`, `getDescription()`, `getProperties()`, `invoke()` |
 | `Tool.php` | Base class with property definitions |
+| `ToolOutput.php` | DTO carrying a tool's result (text and/or `ContentBlockInterface[]`) |
+| `HasOutput.php` | Opt-in interface for tools that expose `getOutput(): ToolOutput` |
 | `ProviderTool.php` | Wrapper for MCP server tools |
 | `ProviderToolInterface.php` | Contract for provider-exposed tools |
+
+## Returning rich content (ToolOutput)
+
+By default a tool's `__invoke` returns a string (or an array, which is JSON-encoded for backwards compatibility). The provider mappers feed that string into the tool-result field of the underlying API.
+
+To return rich content — text alongside images, documents, etc. — return a `NeuronAI\Tools\ToolOutput` from `__invoke`. The DTO is the **only** signal that the result carries content blocks; arrays are always JSON-encoded and never inspected for `ContentBlockInterface` instances.
+
+```php
+use NeuronAI\Chat\Enums\SourceType;
+use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
+use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolOutput;
+
+class CaptureTool extends Tool
+{
+    public function __invoke(string $target): ToolOutput
+    {
+        return ToolOutput::blocks([
+            new TextContent('Snapshot of ' . $target),
+            new ImageContent($this->snapshot($target), SourceType::BASE64, 'image/png'),
+        ]);
+    }
+}
+```
+
+### `ToolOutput` API
+
+| Method | Returns |
+|--------|---------|
+| `ToolOutput::text(string $text)` | Static factory, text-only result |
+| `ToolOutput::blocks(ContentBlockInterface[] $blocks)` | Static factory, blocks-only result |
+| `new ToolOutput(?string $text = null, array $blocks = [])` | Mixed (text + blocks) |
+| `hasBlocks()` | `true` when blocks were provided |
+| `getBlocks()` | `ContentBlockInterface[]` |
+| `getText()` | Explicit text, or concatenation of `TextContent` blocks, or `null` |
+
+### Provider support
+
+Provider mappers honour blocks where the underlying API natively accepts them, and fall back to the text path otherwise.
+
+| Provider | Behaviour with blocks |
+|----------|-----------------------|
+| Anthropic | Emits `tool_result.content` as native block array (`text`, `image`, `document`) |
+| AWS Bedrock | Emits `toolResult.content` as native block array (`text`, `image`, `document`, `video`, `audio`) |
+| Gemini | Emits `functionResponse.response.content.parts` (`text`, `inline_data`, `file_data`) |
+| OpenAI Chat Completions | Emits `content` as native block array (`text`, `image_url`); inherited by Cohere, Deepseek, ZAI |
+| Ollama, Mistral, OpenAI Responses | Text-only — falls back to `ToolOutput::getText()` |
+
+### Tool accessors
+
+- `Tool::getResult(): string` — backwards-compatible string (explicit text or concatenated text blocks). Still declared on `ToolInterface`.
+- `Tool::getOutput(): ToolOutput` — structured payload. Declared on the `HasOutput` interface (which `Tool` implements); any `ToolInterface` implementation can opt in by implementing `HasOutput`. Provider mappers detect rich output via `instanceof HasOutput`, not by coupling to the concrete `Tool` class.
+- `Tool::jsonSerialize()` — emits both keys: `result` (string, BC) and `resultOutput` (the `ToolOutput` payload).
 
 ## Creating Custom Tools
 

--- a/src/Tools/AGENTS.md
+++ b/src/Tools/AGENTS.md
@@ -59,7 +59,8 @@ Provider mappers honour blocks where the underlying API natively accepts them, a
 | AWS Bedrock | Emits `toolResult.content` as native block array (`text`, `image`, `document`, `video`, `audio`) |
 | Gemini | Emits `functionResponse.response.content.parts` (`text`, `inline_data`, `file_data`) |
 | OpenAI Chat Completions | Emits `content` as native block array (`text`, `image_url`); inherited by Cohere, Deepseek, ZAI |
-| Ollama, Mistral, OpenAI Responses | Text-only — falls back to `ToolOutput::getText()` |
+| OpenAI Responses | Emits `function_call_output.output` as native block array (`input_text`, `input_image`, `input_file`) |
+| Ollama, Mistral | Text-only — falls back to `ToolOutput::getText()` |
 
 ### Tool accessors
 

--- a/src/Tools/AGENTS.md
+++ b/src/Tools/AGENTS.md
@@ -60,7 +60,8 @@ Provider mappers honour blocks where the underlying API natively accepts them, a
 | Gemini | Emits `functionResponse.response.content.parts` (`text`, `inline_data`, `file_data`) |
 | OpenAI Chat Completions | Emits `content` as native block array (`text`, `image_url`); inherited by Cohere, Deepseek, ZAI |
 | OpenAI Responses | Emits `function_call_output.output` as native block array (`input_text`, `input_image`, `input_file`) |
-| Ollama, Mistral | Text-only — falls back to `ToolOutput::getText()` |
+| Mistral | Emits `content` as native block array (`text`, `image_url`, `document_url`, `input_audio`) |
+| Ollama | Text-only — falls back to `ToolOutput::getText()` |
 
 ### Tool accessors
 

--- a/src/Tools/HasOutput.php
+++ b/src/Tools/HasOutput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tools;
+
+/**
+ * Opt-in contract for tools that expose a structured result payload via
+ * getOutput(). Tools implementing this interface can return ContentBlock
+ * instances alongside (or instead of) text, and provider mappers that
+ * support rich tool results will emit them natively.
+ *
+ * ToolInterface implementations are NOT required to implement this; the
+ * classic getResult(): string path remains the default.
+ */
+interface HasOutput
+{
+    public function getOutput(): ToolOutput;
+}

--- a/src/Tools/HasOutput.php
+++ b/src/Tools/HasOutput.php
@@ -5,13 +5,8 @@ declare(strict_types=1);
 namespace NeuronAI\Tools;
 
 /**
- * Opt-in contract for tools that expose a structured result payload via
- * getOutput(). Tools implementing this interface can return ContentBlock
- * instances alongside (or instead of) text, and provider mappers that
- * support rich tool results will emit them natively.
- *
- * ToolInterface implementations are NOT required to implement this; the
- * classic getResult(): string path remains the default.
+ * Opt-in interface for tools that expose a structured result via getOutput().
+ * Provider mappers honor blocks where the underlying API supports them.
  */
 interface HasOutput
 {

--- a/src/Tools/Tool.php
+++ b/src/Tools/Tool.php
@@ -180,11 +180,6 @@ class Tool implements ToolInterface, HasOutput
         return $this->result?->getText() ?? '';
     }
 
-    /**
-     * Returns the structured result payload. Tools that returned a plain
-     * string or array expose it as text; tools that returned a ToolOutput
-     * expose both text and any content blocks.
-     */
     public function getOutput(): ToolOutput
     {
         return $this->result ?? ToolOutput::text('');

--- a/src/Tools/Tool.php
+++ b/src/Tools/Tool.php
@@ -24,7 +24,7 @@ use function method_exists;
 /**
  * @method static static make(?string $name = null, ?string $description = null, array $properties = [], array $parameters = [], array $annotations = [])
  */
-class Tool implements ToolInterface
+class Tool implements ToolInterface, HasOutput
 {
     use StaticConstructor;
 
@@ -46,7 +46,7 @@ class Tool implements ToolInterface
     /**
      * The result of the execution.
      */
-    protected string|null $result = null;
+    protected ?ToolOutput $result = null;
 
     /**
      * Define the maximum number of calls for the tool in a single agent session.
@@ -177,7 +177,17 @@ class Tool implements ToolInterface
 
     public function getResult(): string
     {
-        return $this->result;
+        return $this->result?->getText() ?? '';
+    }
+
+    /**
+     * Returns the structured result payload. Tools that returned a plain
+     * string or array expose it as text; tools that returned a ToolOutput
+     * expose both text and any content blocks.
+     */
+    public function getOutput(): ToolOutput
+    {
+        return $this->result ?? ToolOutput::text('');
     }
 
     /**
@@ -185,7 +195,11 @@ class Tool implements ToolInterface
      */
     public function setResult(mixed $result): self
     {
-        $this->result = is_array($result) ? json_encode($result) : (string) $result;
+        $this->result = match (true) {
+            $result instanceof ToolOutput => $result,
+            is_array($result) => ToolOutput::text((string) json_encode($result)),
+            default => ToolOutput::text((string) $result),
+        };
 
         return $this;
     }
@@ -303,7 +317,8 @@ class Tool implements ToolInterface
             'description' => $this->description,
             'parameters' => $this->parameters,
             'inputs' => $this->inputs === [] ? new stdClass() : $this->inputs,
-            'result' => $this->result,
+            'result' => $this->getResult(),
+            'resultOutput' => $this->result,
         ];
     }
 }

--- a/src/Tools/ToolOutput.php
+++ b/src/Tools/ToolOutput.php
@@ -12,9 +12,8 @@ use function array_map;
 use function implode;
 
 /**
- * Carrier for a tool's execution result. Tools that only return text can keep
- * returning strings; tools that need to emit rich content (text + images,
- * documents, etc.) return a ToolOutput built via ToolOutput::blocks().
+ * Carrier for a tool's execution result. Return via ToolOutput::blocks() to
+ * emit rich content (images, documents, etc.) alongside text.
  */
 final class ToolOutput implements JsonSerializable
 {

--- a/src/Tools/ToolOutput.php
+++ b/src/Tools/ToolOutput.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tools;
+
+use JsonSerializable;
+use NeuronAI\Chat\Messages\ContentBlocks\ContentBlockInterface;
+use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
+
+use function array_map;
+use function implode;
+
+/**
+ * Carrier for a tool's execution result. Tools that only return text can keep
+ * returning strings; tools that need to emit rich content (text + images,
+ * documents, etc.) return a ToolOutput built via ToolOutput::blocks().
+ */
+final class ToolOutput implements JsonSerializable
+{
+    /**
+     * @param ContentBlockInterface[] $blocks
+     */
+    public function __construct(
+        public readonly ?string $text = null,
+        public readonly array $blocks = [],
+    ) {
+    }
+
+    public static function text(string $text): self
+    {
+        return new self(text: $text);
+    }
+
+    /**
+     * @param ContentBlockInterface[] $blocks
+     */
+    public static function blocks(array $blocks): self
+    {
+        return new self(blocks: $blocks);
+    }
+
+    public function hasBlocks(): bool
+    {
+        return $this->blocks !== [];
+    }
+
+    /**
+     * @return ContentBlockInterface[]
+     */
+    public function getBlocks(): array
+    {
+        return $this->blocks;
+    }
+
+    /**
+     * Returns the explicit text payload, or the concatenation of TextContent
+     * blocks when no explicit text was set. Returns null when neither text nor
+     * any text-bearing block is present.
+     */
+    public function getText(): ?string
+    {
+        if ($this->text !== null) {
+            return $this->text;
+        }
+
+        $texts = [];
+        foreach ($this->blocks as $block) {
+            if ($block instanceof TextContent && $block->content !== '') {
+                $texts[] = $block->content;
+            }
+        }
+
+        return $texts === [] ? null : implode(' ', $texts);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'text' => $this->text,
+            'blocks' => array_map(
+                static fn (ContentBlockInterface $block): array => $block->toArray(),
+                $this->blocks,
+            ),
+        ];
+    }
+}

--- a/tests/Adapters/AgUIAdapterTest.php
+++ b/tests/Adapters/AgUIAdapterTest.php
@@ -275,13 +275,6 @@ class AgUIAdapterTest extends TestCase
                 $this->inputs = $inputs;
             }
 
-            public function setResult(mixed $result): self
-            {
-                $this->result = $result;
-
-                return $this;
-            }
-
             public function description(): string
             {
                 return 'Mock tool';

--- a/tests/Adapters/VercelAIAdapterTest.php
+++ b/tests/Adapters/VercelAIAdapterTest.php
@@ -177,12 +177,6 @@ class VercelAIAdapterTest extends TestCase
                 $this->inputs = $inputs;
             }
 
-            public function setResult(mixed $result): self
-            {
-                $this->result = $result;
-                return $this;
-            }
-
             public function description(): string
             {
                 return 'Mock tool';

--- a/tests/ChatHistory/ToolOutputHydrationTest.php
+++ b/tests/ChatHistory/ToolOutputHydrationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\ChatHistory;
+
+use NeuronAI\Chat\Enums\SourceType;
+use NeuronAI\Chat\History\FileChatHistory;
+use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
+use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
+use NeuronAI\Chat\Messages\ToolCallMessage;
+use NeuronAI\Chat\Messages\ToolResultMessage;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolOutput;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function unlink;
+use function file_exists;
+use function file_put_contents;
+use function json_encode;
+
+use const DIRECTORY_SEPARATOR;
+
+class ToolOutputHydrationTest extends TestCase
+{
+    private string $key = 'tool_output_hydration_test';
+
+    protected function tearDown(): void
+    {
+        $file = __DIR__ . DIRECTORY_SEPARATOR . 'neuron_' . $this->key . '.chat';
+        if (file_exists($file)) {
+            unlink($file);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_block_result_survives_round_trip_through_file_chat_history(): void
+    {
+        $originalTool = Tool::make('capture', 'snapshots stuff')
+            ->setCallId('call_1')
+            ->setResult(ToolOutput::blocks([
+                new TextContent('caption'),
+                new ImageContent('aGVsbG8=', SourceType::BASE64, 'image/png'),
+            ]));
+
+        $persist = new FileChatHistory(__DIR__, $this->key);
+        $persist->addMessage(new ToolCallMessage(tools: [$originalTool]));
+        $persist->addMessage(new ToolResultMessage([$originalTool]));
+
+        $raw = json_decode((string) file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'neuron_' . $this->key . '.chat'), true);
+        $persistedTool = $raw[1]['tools'][0];
+        $this->assertArrayNotHasKey('result', $persistedTool, 'result key should be stripped when resultOutput has blocks');
+        $this->assertArrayHasKey('resultOutput', $persistedTool);
+        $this->assertCount(2, $persistedTool['resultOutput']['blocks']);
+
+        $reload = new FileChatHistory(__DIR__, $this->key);
+        $messages = $reload->getMessages();
+
+        $this->assertCount(2, $messages);
+        $this->assertInstanceOf(ToolResultMessage::class, $messages[1]);
+
+        $reloadedMessage = $messages[1];
+        $this->assertInstanceOf(ToolResultMessage::class, $reloadedMessage);
+        $reloadedTool = $reloadedMessage->getTools()[0];
+        $this->assertInstanceOf(Tool::class, $reloadedTool);
+        $this->assertTrue($reloadedTool->getOutput()->hasBlocks(), 'blocks lost during hydration');
+
+        $blocks = $reloadedTool->getOutput()->getBlocks();
+        $this->assertCount(2, $blocks);
+        $this->assertInstanceOf(TextContent::class, $blocks[0]);
+        $this->assertSame('caption', $blocks[0]->content);
+        $this->assertInstanceOf(ImageContent::class, $blocks[1]);
+        $this->assertSame('aGVsbG8=', $blocks[1]->content);
+        $this->assertSame('image/png', $blocks[1]->mediaType);
+        $this->assertSame(SourceType::BASE64, $blocks[1]->sourceType);
+
+        // getResult() still returns text (derived from TextContent blocks)
+        $this->assertSame('caption', $reloadedTool->getResult());
+    }
+
+    public function test_text_only_result_round_trips_via_bc_string_path(): void
+    {
+        $originalTool = Tool::make('search', 'searches stuff')
+            ->setCallId('call_2')
+            ->setResult('plain-result');
+
+        $persist = new FileChatHistory(__DIR__, $this->key);
+        $persist->addMessage(new ToolCallMessage(tools: [$originalTool]));
+        $persist->addMessage(new ToolResultMessage([$originalTool]));
+
+        $reload = new FileChatHistory(__DIR__, $this->key);
+        $messages = $reload->getMessages();
+
+        $reloadedMessage = $messages[1];
+        $this->assertInstanceOf(ToolResultMessage::class, $reloadedMessage);
+        $reloadedTool = $reloadedMessage->getTools()[0];
+        $this->assertInstanceOf(Tool::class, $reloadedTool);
+        $this->assertSame('plain-result', $reloadedTool->getResult());
+    }
+
+    public function test_legacy_persisted_payload_without_result_output_key_still_loads(): void
+    {
+        // Simulate a legacy history file written before ToolOutput existed:
+        // only 'result' (string) is present, no 'resultOutput'.
+        $payload = [
+            [
+                'type' => 'tool_call',
+                'role' => 'assistant',
+                'tools' => [
+                    [
+                        'callId' => 'call_legacy',
+                        'name' => 'legacy',
+                        'description' => 'legacy tool',
+                        'parameters' => [],
+                        'inputs' => new stdClass(),
+                    ],
+                ],
+            ],
+            [
+                'type' => 'tool_call_result',
+                'role' => 'user',
+                'tools' => [
+                    [
+                        'callId' => 'call_legacy',
+                        'name' => 'legacy',
+                        'description' => 'legacy tool',
+                        'parameters' => [],
+                        'inputs' => new stdClass(),
+                        'result' => 'legacy-string-result',
+                    ],
+                ],
+            ],
+        ];
+
+        $file = __DIR__ . DIRECTORY_SEPARATOR . 'neuron_' . $this->key . '.chat';
+        file_put_contents($file, json_encode($payload));
+
+        $reload = new FileChatHistory(__DIR__, $this->key);
+        $messages = $reload->getMessages();
+
+        $reloadedMessage = $messages[1];
+        $this->assertInstanceOf(ToolResultMessage::class, $reloadedMessage);
+        $reloadedTool = $reloadedMessage->getTools()[0];
+        $this->assertInstanceOf(Tool::class, $reloadedTool);
+        $this->assertSame('legacy-string-result', $reloadedTool->getResult());
+    }
+}

--- a/tests/ChatHistory/ToolOutputHydrationTest.php
+++ b/tests/ChatHistory/ToolOutputHydrationTest.php
@@ -19,6 +19,8 @@ use function unlink;
 use function file_exists;
 use function file_put_contents;
 use function json_encode;
+use function file_get_contents;
+use function json_decode;
 
 use const DIRECTORY_SEPARATOR;
 

--- a/tests/Providers/ToolOutputMapperTest.php
+++ b/tests/Providers/ToolOutputMapperTest.php
@@ -12,6 +12,7 @@ use NeuronAI\Providers\Anthropic\MessageMapper as AnthropicMessageMapper;
 use NeuronAI\Providers\AWS\MessageMapper as AWSMessageMapper;
 use NeuronAI\Providers\Gemini\MessageMapper as GeminiMessageMapper;
 use NeuronAI\Providers\OpenAI\MessageMapper as OpenAIMessageMapper;
+use NeuronAI\Providers\OpenAI\Responses\MessageMapper as OpenAIResponsesMessageMapper;
 use NeuronAI\Tools\HasOutput;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolInterface;
@@ -121,6 +122,31 @@ class ToolOutputMapperTest extends TestCase
         $decoded = $this->decode($payload);
 
         $this->assertSame('plain-result', $decoded[0]['content']);
+    }
+
+    public function test_openai_responses_emits_native_blocks_when_output_has_blocks(): void
+    {
+        $tool = $this->buildBlockTool();
+
+        $payload = (new OpenAIResponsesMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        // First (and only) entry is the function_call_output item
+        $this->assertSame('function_call_output', $decoded[0]['type']);
+        $this->assertIsArray($decoded[0]['output']);
+        $this->assertSame('input_text', $decoded[0]['output'][0]['type']);
+        $this->assertSame('caption', $decoded[0]['output'][0]['text']);
+        $this->assertSame('input_image', $decoded[0]['output'][1]['type']);
+    }
+
+    public function test_openai_responses_falls_back_to_string_when_no_blocks(): void
+    {
+        $tool = $this->buildTextTool();
+
+        $payload = (new OpenAIResponsesMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $this->assertSame('plain-result', $decoded[0]['output']);
     }
 
     public function test_mapper_honors_custom_tool_implementing_has_output(): void

--- a/tests/Providers/ToolOutputMapperTest.php
+++ b/tests/Providers/ToolOutputMapperTest.php
@@ -226,8 +226,6 @@ class ToolOutputMapperTest extends TestCase
             $payload = $mapper->map([new ToolResultMessage([$tool])]);
             $decoded = $this->decode($payload);
 
-            // Each provider emits the block somewhere in its shape; the test
-            // just asserts that the custom-tool block content appears in JSON.
             $json = (string) json_encode($decoded);
             $this->assertStringContainsString('from-custom', $json, $mapper::class . ' did not honor HasOutput');
         }

--- a/tests/Providers/ToolOutputMapperTest.php
+++ b/tests/Providers/ToolOutputMapperTest.php
@@ -11,6 +11,7 @@ use NeuronAI\Chat\Messages\ToolResultMessage;
 use NeuronAI\Providers\Anthropic\MessageMapper as AnthropicMessageMapper;
 use NeuronAI\Providers\AWS\MessageMapper as AWSMessageMapper;
 use NeuronAI\Providers\Gemini\MessageMapper as GeminiMessageMapper;
+use NeuronAI\Providers\Mistral\MessageMapper as MistralMessageMapper;
 use NeuronAI\Providers\OpenAI\MessageMapper as OpenAIMessageMapper;
 use NeuronAI\Providers\OpenAI\Responses\MessageMapper as OpenAIResponsesMessageMapper;
 use NeuronAI\Tools\HasOutput;
@@ -147,6 +148,29 @@ class ToolOutputMapperTest extends TestCase
         $decoded = $this->decode($payload);
 
         $this->assertSame('plain-result', $decoded[0]['output']);
+    }
+
+    public function test_mistral_emits_native_blocks_when_output_has_blocks(): void
+    {
+        $tool = $this->buildBlockTool();
+
+        $payload = (new MistralMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $this->assertIsArray($decoded[0]['content']);
+        $this->assertSame('text', $decoded[0]['content'][0]['type']);
+        $this->assertSame('caption', $decoded[0]['content'][0]['text']);
+        $this->assertSame('image_url', $decoded[0]['content'][1]['type']);
+    }
+
+    public function test_mistral_falls_back_to_string_when_no_blocks(): void
+    {
+        $tool = $this->buildTextTool();
+
+        $payload = (new MistralMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $this->assertSame('plain-result', $decoded[0]['content']);
     }
 
     public function test_mapper_honors_custom_tool_implementing_has_output(): void

--- a/tests/Providers/ToolOutputMapperTest.php
+++ b/tests/Providers/ToolOutputMapperTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\Providers;
+
+use NeuronAI\Chat\Enums\SourceType;
+use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
+use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
+use NeuronAI\Chat\Messages\ToolResultMessage;
+use NeuronAI\Providers\Anthropic\MessageMapper as AnthropicMessageMapper;
+use NeuronAI\Providers\AWS\MessageMapper as AWSMessageMapper;
+use NeuronAI\Providers\Gemini\MessageMapper as GeminiMessageMapper;
+use NeuronAI\Providers\OpenAI\MessageMapper as OpenAIMessageMapper;
+use NeuronAI\Tools\HasOutput;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolInterface;
+use NeuronAI\Tools\ToolOutput;
+use PHPUnit\Framework\TestCase;
+
+use function json_decode;
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+
+class ToolOutputMapperTest extends TestCase
+{
+    public function test_anthropic_emits_native_blocks_when_output_has_blocks(): void
+    {
+        $tool = $this->buildBlockTool();
+
+        $payload = (new AnthropicMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $block = $decoded[0]['content'][0];
+        $this->assertSame('tool_result', $block['type']);
+        $this->assertIsArray($block['content']);
+        $this->assertSame('caption', $block['content'][0]['text']);
+        $this->assertSame('image', $block['content'][1]['type']);
+        $this->assertSame('base64', $block['content'][1]['source']['type']);
+        $this->assertSame('aGVsbG8=', $block['content'][1]['source']['data']);
+    }
+
+    public function test_anthropic_falls_back_to_string_when_no_blocks(): void
+    {
+        $tool = $this->buildTextTool();
+
+        $payload = (new AnthropicMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $this->assertSame('plain-result', $decoded[0]['content'][0]['content']);
+    }
+
+    public function test_aws_emits_native_blocks_when_output_has_blocks(): void
+    {
+        $tool = $this->buildBlockTool();
+
+        $payload = (new AWSMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $content = $decoded[0]['content'][0]['toolResult']['content'];
+        $this->assertSame('caption', $content[0]['text']);
+        $this->assertArrayHasKey('image', $content[1]);
+    }
+
+    public function test_aws_falls_back_to_json_wrapper_when_no_blocks(): void
+    {
+        $tool = $this->buildTextTool();
+
+        $payload = (new AWSMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $content = $decoded[0]['content'][0]['toolResult']['content'];
+        $this->assertSame('plain-result', $content[0]['json']['result']);
+    }
+
+    public function test_gemini_emits_parts_when_output_has_blocks(): void
+    {
+        $tool = $this->buildBlockTool();
+
+        $payload = (new GeminiMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $response = $decoded[0]['parts'][0]['functionResponse']['response'];
+        $this->assertIsArray($response['content']);
+        $this->assertArrayHasKey('parts', $response['content']);
+        $this->assertSame('caption', $response['content']['parts'][0]['text']);
+        // ImageContent BASE64 maps to inline_data
+        $this->assertSame('aGVsbG8=', $response['content']['parts'][1]['inline_data']['data']);
+    }
+
+    public function test_gemini_falls_back_to_string_when_no_blocks(): void
+    {
+        $tool = $this->buildTextTool();
+
+        $payload = (new GeminiMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $response = $decoded[0]['parts'][0]['functionResponse']['response'];
+        $this->assertSame('plain-result', $response['content']);
+    }
+
+    public function test_openai_emits_content_array_when_output_has_blocks(): void
+    {
+        $tool = $this->buildBlockTool();
+
+        $payload = (new OpenAIMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $this->assertIsArray($decoded[0]['content']);
+        $this->assertSame('text', $decoded[0]['content'][0]['type']);
+        $this->assertSame('caption', $decoded[0]['content'][0]['text']);
+        $this->assertSame('image_url', $decoded[0]['content'][1]['type']);
+    }
+
+    public function test_openai_falls_back_to_string_when_no_blocks(): void
+    {
+        $tool = $this->buildTextTool();
+
+        $payload = (new OpenAIMessageMapper())->map([new ToolResultMessage([$tool])]);
+        $decoded = $this->decode($payload);
+
+        $this->assertSame('plain-result', $decoded[0]['content']);
+    }
+
+    public function test_mapper_honors_custom_tool_implementing_has_output(): void
+    {
+        // A class that implements ToolInterface directly (not extending Tool)
+        // but opts into rich output via HasOutput. Mappers must accept it.
+        $tool = new class () implements ToolInterface, HasOutput {
+            public function getName(): string
+            {
+                return 'custom';
+            }
+            public function setName(string $name): ToolInterface
+            {
+                return $this;
+            }
+            public function getDescription(): ?string
+            {
+                return null;
+            }
+            public function setDescription(?string $description): ToolInterface
+            {
+                return $this;
+            }
+            public function addProperty(\NeuronAI\Tools\ToolPropertyInterface $property): ToolInterface
+            {
+                return $this;
+            }
+            public function getProperties(): array
+            {
+                return [];
+            }
+            public function getRequiredProperties(): array
+            {
+                return [];
+            }
+            public function getParameters(): array
+            {
+                return [];
+            }
+            public function getInputs(): array
+            {
+                return [];
+            }
+            public function getInput(string $key): mixed
+            {
+                return null;
+            }
+            public function setInputs(?array $inputs): ToolInterface
+            {
+                return $this;
+            }
+            public function getCallId(): string
+            {
+                return 'call_custom';
+            }
+            public function setCallId(string $callId): ToolInterface
+            {
+                return $this;
+            }
+            public function getResult(): string
+            {
+                return 'custom-text';
+            }
+            public function getMaxRuns(): ?int
+            {
+                return null;
+            }
+            public function setMaxRuns(int $tries): ToolInterface
+            {
+                return $this;
+            }
+            public function visible(bool $visible): ToolInterface
+            {
+                return $this;
+            }
+            public function isVisible(): bool
+            {
+                return true;
+            }
+            public function setCallable(callable $callback): ToolInterface
+            {
+                return $this;
+            }
+            public function execute(): void
+            {
+            }
+            public function jsonSerialize(): array
+            {
+                return [];
+            }
+            public function getOutput(): ToolOutput
+            {
+                return ToolOutput::blocks([new TextContent('from-custom')]);
+            }
+        };
+
+        foreach ([
+            new AnthropicMessageMapper(),
+            new AWSMessageMapper(),
+            new GeminiMessageMapper(),
+            new OpenAIMessageMapper(),
+        ] as $mapper) {
+            $payload = $mapper->map([new ToolResultMessage([$tool])]);
+            $decoded = $this->decode($payload);
+
+            // Each provider emits the block somewhere in its shape; the test
+            // just asserts that the custom-tool block content appears in JSON.
+            $json = (string) json_encode($decoded);
+            $this->assertStringContainsString('from-custom', $json, $mapper::class . ' did not honor HasOutput');
+        }
+    }
+
+    private function buildBlockTool(): Tool
+    {
+        $tool = Tool::make('block_tool', 'returns blocks');
+        $tool->setCallId('call_1');
+        $tool->setResult(ToolOutput::blocks([
+            new TextContent('caption'),
+            new ImageContent('aGVsbG8=', SourceType::BASE64, 'image/png'),
+        ]));
+        return $tool;
+    }
+
+    private function buildTextTool(): Tool
+    {
+        $tool = Tool::make('text_tool', 'returns text');
+        $tool->setCallId('call_1');
+        $tool->setResult('plain-result');
+        return $tool;
+    }
+
+    private function decode(array $payload): array
+    {
+        return json_decode(json_encode($payload, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Tools/ToolOutputTest.php
+++ b/tests/Tools/ToolOutputTest.php
@@ -126,8 +126,6 @@ class ToolOutputTest extends TestCase
 
     public function test_set_result_array_of_content_blocks_is_json_encoded_not_treated_as_blocks(): void
     {
-        // Per design: arrays are ALWAYS JSON-encoded. To return blocks, the tool
-        // must explicitly return a ToolOutput. This removes any ambiguity.
         $tool = Tool::make('t', 'd');
         $block = new TextContent('block-in-array');
         $tool->setResult([$block]);
@@ -184,9 +182,7 @@ class ToolOutputTest extends TestCase
         // Round-trip through JSON so JsonSerializable inner objects get encoded
         $serialized = json_decode(json_encode($tool->jsonSerialize()), true);
 
-        // 'result' is the BC string path
         $this->assertSame('block-text', $serialized['result']);
-        // 'resultOutput' is the structured payload
         $this->assertArrayHasKey('resultOutput', $serialized);
         $this->assertIsArray($serialized['resultOutput']);
         $this->assertCount(1, $serialized['resultOutput']['blocks']);

--- a/tests/Tools/ToolOutputTest.php
+++ b/tests/Tools/ToolOutputTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\Tools;
+
+use NeuronAI\Chat\Enums\SourceType;
+use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
+use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolOutput;
+use PHPUnit\Framework\TestCase;
+
+use function json_decode;
+use function json_encode;
+
+class ToolOutputTest extends TestCase
+{
+    public function test_text_factory_stores_text(): void
+    {
+        $output = ToolOutput::text('hello');
+
+        $this->assertSame('hello', $output->getText());
+        $this->assertFalse($output->hasBlocks());
+        $this->assertSame([], $output->getBlocks());
+    }
+
+    public function test_blocks_factory_stores_blocks(): void
+    {
+        $blocks = [new TextContent('a'), new TextContent('b')];
+        $output = ToolOutput::blocks($blocks);
+
+        $this->assertTrue($output->hasBlocks());
+        $this->assertSame($blocks, $output->getBlocks());
+        // getText() derives from TextContent blocks when no explicit text
+        $this->assertSame('a b', $output->getText());
+    }
+
+    public function test_blocks_factory_with_non_text_blocks_has_null_text(): void
+    {
+        $output = ToolOutput::blocks([
+            new ImageContent('aGVsbG8=', SourceType::BASE64, 'image/png'),
+        ]);
+
+        $this->assertNull($output->getText());
+    }
+
+    public function test_get_text_joins_text_blocks_when_no_explicit_text(): void
+    {
+        $output = ToolOutput::blocks([new TextContent('foo'), new TextContent('bar')]);
+
+        $this->assertSame('foo bar', $output->getText());
+    }
+
+    public function test_get_text_skips_non_text_blocks(): void
+    {
+        $output = ToolOutput::blocks([
+            new TextContent('caption'),
+            new ImageContent('aGVsbG8=', SourceType::BASE64, 'image/png'),
+        ]);
+
+        $this->assertSame('caption', $output->getText());
+    }
+
+    public function test_get_text_returns_null_when_blocks_have_no_text(): void
+    {
+        $output = ToolOutput::blocks([
+            new ImageContent('aGVsbG8=', SourceType::BASE64, 'image/png'),
+        ]);
+
+        $this->assertNull($output->getText());
+    }
+
+    public function test_explicit_text_takes_precedence_over_blocks(): void
+    {
+        $output = new ToolOutput(
+            text: 'explicit',
+            blocks: [new TextContent('from-block')],
+        );
+
+        $this->assertSame('explicit', $output->getText());
+        $this->assertTrue($output->hasBlocks());
+    }
+
+    public function test_json_serialize_shape(): void
+    {
+        $output = new ToolOutput(
+            text: 'fallback',
+            blocks: [new TextContent('block-text')],
+        );
+
+        $serialized = $output->jsonSerialize();
+
+        $this->assertSame('fallback', $serialized['text']);
+        $this->assertCount(1, $serialized['blocks']);
+        $this->assertSame('block-text', $serialized['blocks'][0]['content']);
+    }
+
+    public function test_set_result_string_normalizes_to_text_output(): void
+    {
+        $tool = Tool::make('t', 'd');
+        $tool->setResult('plain');
+
+        $this->assertSame('plain', $tool->getResult());
+        $this->assertFalse($tool->getOutput()->hasBlocks());
+        $this->assertSame('plain', $tool->getOutput()->getText());
+    }
+
+    public function test_set_result_assoc_array_is_json_encoded_for_bc(): void
+    {
+        $tool = Tool::make('t', 'd');
+        $tool->setResult(['foo' => 'bar']);
+
+        $this->assertSame('{"foo":"bar"}', $tool->getResult());
+        $this->assertFalse($tool->getOutput()->hasBlocks());
+    }
+
+    public function test_set_result_list_array_is_json_encoded_for_bc(): void
+    {
+        $tool = Tool::make('t', 'd');
+        $tool->setResult(['a', 'b']);
+
+        $this->assertSame('["a","b"]', $tool->getResult());
+        $this->assertFalse($tool->getOutput()->hasBlocks());
+    }
+
+    public function test_set_result_array_of_content_blocks_is_json_encoded_not_treated_as_blocks(): void
+    {
+        // Per design: arrays are ALWAYS JSON-encoded. To return blocks, the tool
+        // must explicitly return a ToolOutput. This removes any ambiguity.
+        $tool = Tool::make('t', 'd');
+        $block = new TextContent('block-in-array');
+        $tool->setResult([$block]);
+
+        $this->assertFalse($tool->getOutput()->hasBlocks());
+        $this->assertNotSame([$block], $tool->getOutput()->getBlocks());
+    }
+
+    public function test_set_result_null_yields_empty_text(): void
+    {
+        $tool = Tool::make('t', 'd');
+        $tool->setResult(null);
+
+        $this->assertSame('', $tool->getResult());
+        $this->assertSame('', $tool->getOutput()->getText());
+    }
+
+    public function test_set_result_scalar_is_cast_to_string(): void
+    {
+        $tool = Tool::make('t', 'd');
+        $tool->setResult(42);
+
+        $this->assertSame('42', $tool->getResult());
+    }
+
+    public function test_set_result_tool_output_is_passed_through(): void
+    {
+        $tool = Tool::make('t', 'd');
+        $output = ToolOutput::blocks([
+            new TextContent('caption'),
+            new ImageContent('aGVsbG8=', SourceType::BASE64, 'image/png'),
+        ]);
+        $tool->setResult($output);
+
+        $this->assertTrue($tool->getOutput()->hasBlocks());
+        $this->assertSame($output, $tool->getOutput());
+        // getResult falls back to joining TextContent blocks
+        $this->assertSame('caption', $tool->getResult());
+    }
+
+    public function test_get_result_is_empty_string_before_set_result(): void
+    {
+        $tool = Tool::make('t', 'd');
+
+        $this->assertSame('', $tool->getResult());
+        $this->assertFalse($tool->getOutput()->hasBlocks());
+    }
+
+    public function test_json_serialize_emits_string_result_and_result_output(): void
+    {
+        $tool = Tool::make('t', 'd');
+        $tool->setResult(ToolOutput::blocks([new TextContent('block-text')]));
+
+        // Round-trip through JSON so JsonSerializable inner objects get encoded
+        $serialized = json_decode(json_encode($tool->jsonSerialize()), true);
+
+        // 'result' is the BC string path
+        $this->assertSame('block-text', $serialized['result']);
+        // 'resultOutput' is the structured payload
+        $this->assertArrayHasKey('resultOutput', $serialized);
+        $this->assertIsArray($serialized['resultOutput']);
+        $this->assertCount(1, $serialized['resultOutput']['blocks']);
+    }
+
+    public function test_json_serialize_result_output_is_null_when_never_set(): void
+    {
+        $tool = Tool::make('t', 'd');
+
+        $serialized = json_decode(json_encode($tool->jsonSerialize()), true);
+
+        $this->assertSame('', $serialized['result']);
+        $this->assertNull($serialized['resultOutput']);
+    }
+
+    public function test_callable_returning_string_uses_text_path(): void
+    {
+        $tool = Tool::make('t', 'd')
+            ->setCallable(fn (): string => 'plain-text');
+        $tool->execute();
+
+        $this->assertSame('plain-text', $tool->getResult());
+        $this->assertFalse($tool->getOutput()->hasBlocks());
+    }
+
+    public function test_callable_returning_tool_output_uses_blocks_path(): void
+    {
+        $blocks = [new TextContent('block-a'), new TextContent('block-b')];
+
+        $tool = Tool::make('t', 'd')
+            ->setCallable(fn (): ToolOutput => ToolOutput::blocks($blocks));
+        $tool->execute();
+
+        $this->assertTrue($tool->getOutput()->hasBlocks());
+        $this->assertSame($blocks, $tool->getOutput()->getBlocks());
+        // getResult joins text blocks
+        $this->assertSame('block-a block-b', $tool->getResult());
+    }
+}


### PR DESCRIPTION
# Allow tools to return rich content (ToolOutput)

## Problem

Tools could only return text (or arrays that got JSON-encoded into strings). There was no way for a tool to hand back richer content — images, documents, audio, etc. — even when the underlying provider APIs natively support such payloads in tool results.

## Solution

Introduce a `ToolOutput` DTO plus an opt-in `HasOutput` interface. Tools that only need text keep their existing `__invoke(): string` signature; tools that need rich content explicitly return a `ToolOutput` carrying `ContentBlockInterface[]`.

The DTO is the **only** signal that the result carries blocks. Arrays are always JSON-encoded (backwards compatible), so there is zero ambiguity — a tool must explicitly opt in via `ToolOutput::blocks([...])` to get block emission.

## API surface

### `NeuronAI\Tools\ToolOutput` (new)

DTO carrying a tool's structured result.

| Method                                                     | Returns                                                            |
| ---------------------------------------------------------- | ------------------------------------------------------------------ |
| `ToolOutput::text(string $text)`                           | Static factory, text-only result                                   |
| `ToolOutput::blocks(ContentBlockInterface[] $blocks)`      | Static factory, blocks-only result                                 |
| `new ToolOutput(?string $text = null, array $blocks = [])` | Mixed (text + blocks)                                              |
| `hasBlocks()`                                              | `true` when blocks were provided                                   |
| `getBlocks()`                                              | `ContentBlockInterface[]`                                          |
| `getText()`                                                | Explicit text, or concatenation of `TextContent` blocks, or `null` |
| `jsonSerialize()`                                          | `{ text, blocks: [...] }`                                          |

### `NeuronAI\Tools\HasOutput` (new)

Opt-in interface declaring `getOutput(): ToolOutput`. Parallels existing `HasRunKey` / `HasInterrupt` opt-in patterns. Any `ToolInterface` implementation can opt into block emission by implementing `HasOutput` — no need to extend the concrete `Tool` class.

### `Tool` class changes

| Method                           | Behavior                                                                                                                 |
| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| `getResult(): string`            | Unchanged contract on `ToolInterface`. Returns explicit text, or concatenation of `TextContent` blocks. BC.              |
| `setResult(mixed $result): self` | Still off-interface (todo: v4). Accepts `ToolOutput` passthrough; arrays JSON-encoded (BC); everything else string-cast. |
| `getOutput(): ToolOutput`        | New. Declared on `HasOutput`. Returns the structured payload.                                                            |
| `jsonSerialize()`                | Emits both `result` (string, BC) and `resultOutput` (the `ToolOutput` payload).                                          |

### `setResult(mixed)` normalization matrix

| Input                                                | Stored as                                         |
| ---------------------------------------------------- | ------------------------------------------------- |
| `null`, `string`, scalar, `Stringable`               | `ToolOutput::text((string) $x)`                   |
| `array` (any shape — assoc, list, mixed)             | `ToolOutput::text(json_encode($x))` — strict BC   |
| `ToolOutput`                                         | passthrough                                       |
| anything else (incl. single `ContentBlockInterface`) | `(string)` cast → natural error (no `__toString`) |

## Persistence & hydration

`ToolOutput` round-trips through chat history stores (File, SQL, Eloquent).

- **Serialization** (`ToolResultMessage::jsonSerialize()`): for tools implementing `HasOutput` whose output has blocks, the redundant BC `result` string is stripped — `resultOutput` is the canonical payload. This avoids duplicating text content (the same string would otherwise appear in both `result` and `resultOutput.blocks[0].content`).
- **Hydration** (`AbstractChatHistory::deserializeToolCallResult()`): when the persisted `resultOutput` has blocks, blocks are reconstructed via the existing `deserializeContentBlock()` machinery; otherwise the legacy `result` string is read.
- **Legacy data**: histories written before this change only have the `result` string and continue to hydrate as text-only outputs. No migration required.

## Provider support

Mappers honor blocks where the underlying API natively accepts them, and fall back to text otherwise. Detection is via `instanceof HasOutput` — no coupling to the concrete `Tool` class.

| Provider                    | Behavior with blocks                                                                                                        |
| --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| **Anthropic**               | `tool_result.content` as native block array (`text`, `image`, `document`) via existing `mapSingleBlock()`                   |
| **AWS Bedrock**             | `toolResult.content` as native block array (`text`, `image`, `document`, `video`, `audio`) via existing `mapContentBlock()` |
| **Gemini**                  | `functionResponse.response.content.parts` array (`text`, `inline_data`, `file_data`)                                        |
| **OpenAI Chat Completions** | `content` as native block array (`text`, `image_url`). Inherited by Cohere, Deepseek, ZAI.                                  |
| **OpenAI Responses**        | `function_call_output.output` as native block array (`input_text`, `input_image`, `input_file`).                            |
| **Mistral**                 | `content` as native block array (`text`, `image_url`, `document_url`, `input_audio`).                                       |
| Ollama                      | Text-only API — falls back to `ToolOutput::getText()`. Unchanged.                                                           |

## Usage example

```php
use NeuronAI\Chat\Enums\SourceType;
use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
use NeuronAI\Tools\Tool;
use NeuronAI\Tools\ToolOutput;

class CaptureTool extends Tool
{
    public function __invoke(string $target): ToolOutput
    {
        return ToolOutput::blocks([
            new TextContent('Snapshot of ' . $target),
            new ImageContent($this->snapshot($target), SourceType::BASE64, 'image/png'),
        ]);
    }
}
```

For text-only tools, nothing changes:

```php
class SearchTool extends Tool
{
    public function __invoke(string $query): string
    {
        return 'results for ' . $query;
    }
}
```

## Backwards compatibility

- `getResult(): string` — signature and semantics preserved for any non-block input.
- `setResult(['foo' => 'bar'])` — still produces `'{"foo":"bar"}'`.
- `setResult('plain text')` — still produces `'plain text'`.
- `ToolInterface` — unchanged.
- Existing tool implementations, chat history serializers, and stream adapters — behavior unchanged.
- Stream adapters (Vercel AI, AG-UI) intentionally unchanged in v1; they continue to consume `getResult()` (text).

## Tests

36 new tests, all green. Existing tests verified BC.

- `tests/Tools/ToolOutputTest.php` (20 tests) — DTO behavior, `setResult` normalization matrix (string/array/null/scalar/`ToolOutput`), `getResult`/`getOutput` accessors, `jsonSerialize` shape, callable returning string vs. `ToolOutput`.
- `tests/Providers/ToolOutputMapperTest.php` (13 tests) — 6 mappers × {blocks path, BC text path} + a custom `ToolInterface + HasOutput` implementation honored by all mappers.
- `tests/ChatHistory/ToolOutputHydrationTest.php` (3 tests) — round-trip through FileChatHistory with blocks; round-trip with text-only (BC); legacy persisted payload without `resultOutput` still hydrates.

PHPStan level 5: clean. PHP CS Fixer: clean.

## Out of scope (future work)

- Promote `setResult` and `getOutput` to `ToolInterface` in v4 (breaking).
- Extend stream adapters (Vercel AI, AG-UI) to emit block-shaped output once those protocols define it.
- Add block emission for Ollama if/when its tool result schema grows beyond text.
