### PR TITLE
Allow Guzzle 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^7.0 || ^8.0",
         "inspector-apm/inspector-php": "^3.18",
         "psr/http-message": "^1.0|^2.0"
     },


### PR DESCRIPTION
## Type of Change

- [x] Improvement/Enhancement (non-breaking change which improves existing functionality)

## Description

Allow Guzzle 8 alongside the existing Guzzle 7 constraint. The current client usage relies on APIs shared by both supported major versions.

## Related Issues

None.

## Breaking Changes

- [x] No breaking changes

## Documentation

- [x] No documentation changes needed