### PR TITLE
Fix VercelAIAdapter text framing for the UI message stream protocol

### DIFF
--- a/src/Chat/Messages/Stream/Adapters/VercelAIAdapter.php
+++ b/src/Chat/Messages/Stream/Adapters/VercelAIAdapter.php
@@ -19,6 +19,8 @@ class VercelAIAdapter extends SSEAdapter
 {
     protected bool $started = false;
 
+    protected ?string $currentTextId = null;
+
     /** @var array<string, string> */
     protected array $toolCallIds = [];
 
@@ -28,6 +30,12 @@ class VercelAIAdapter extends SSEAdapter
         if (!$this->started) {
             $this->started = true;
             yield $this->sse(['type' => 'start', 'messageId' => $chunk->messageId]);
+        }
+
+        // A text part must be closed before any non-text part begins.
+        if (!$chunk instanceof TextChunk && $this->currentTextId !== null) {
+            yield $this->sse(['type' => 'text-end', 'id' => $this->currentTextId]);
+            $this->currentTextId = null;
         }
 
         yield from match (true) {
@@ -41,9 +49,18 @@ class VercelAIAdapter extends SSEAdapter
 
     protected function handleText(TextChunk $chunk): iterable
     {
+        // Every delta of one text part must share ONE id, and the part must be framed by
+        // text-start ... text-end — otherwise the UI message stream client (AI SDK v5+)
+        // cannot assemble the deltas into a message part.
+        // https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol#text-parts
+        if ($this->currentTextId === null) {
+            $this->currentTextId = UniqueIdGenerator::generateId();
+            yield $this->sse(['type' => 'text-start', 'id' => $this->currentTextId]);
+        }
+
         yield $this->sse([
             'type' => 'text-delta',
-            'id' => UniqueIdGenerator::generateId(),
+            'id' => $this->currentTextId,
             'messageId' => $chunk->messageId,
             'delta' => $chunk->content,
         ]);
@@ -100,6 +117,11 @@ class VercelAIAdapter extends SSEAdapter
 
     public function end(): iterable
     {
+        if ($this->currentTextId !== null) {
+            yield $this->sse(['type' => 'text-end', 'id' => $this->currentTextId]);
+            $this->currentTextId = null;
+        }
+
         yield $this->sse(['type' => 'finish']);
         yield "data: [DONE]\n\n";
     }

--- a/tests/Adapters/VercelAIAdapterTest.php
+++ b/tests/Adapters/VercelAIAdapterTest.php
@@ -62,16 +62,63 @@ class VercelAIAdapterTest extends TestCase
             $result[] = $item;
         }
 
-        // Should have 2 messages: start + text-delta
-        $this->assertCount(2, $result);
+        // Should have 3 messages: start + text-start + text-delta
+        $this->assertCount(3, $result);
 
         // First output should be message start
         $this->assertStringContainsString('"type":"start"', $result[0]);
         $this->assertStringContainsString('"messageId":"msg_', $result[0]);
 
-        // Second output should be text delta
-        $this->assertStringContainsString('"type":"text-delta"', $result[1]);
-        $this->assertStringContainsString('"delta":"Hello world"', $result[1]);
+        // Second output opens the text part
+        $this->assertStringContainsString('"type":"text-start"', $result[1]);
+
+        // Third output should be text delta, sharing the text part's id
+        $this->assertStringContainsString('"type":"text-delta"', $result[2]);
+        $this->assertStringContainsString('"delta":"Hello world"', $result[2]);
+
+        preg_match('/"id":"([^"]+)"/', $result[1], $startId);
+        preg_match('/"id":"([^"]+)"/', $result[2], $deltaId);
+        $this->assertEquals($startId[1], $deltaId[1]);
+    }
+
+    public function test_text_parts_are_framed_and_share_one_id(): void
+    {
+        $adapter = new VercelAIAdapter();
+
+        $frames = [];
+        foreach ($adapter->transform(new TextChunk('msg_123', 'Hello')) as $item) {
+            $frames[] = $item;
+        }
+        foreach ($adapter->transform(new TextChunk('msg_123', ' world')) as $item) {
+            $frames[] = $item;
+        }
+
+        // start, text-start, text-delta, text-delta - both deltas share the part id.
+        $this->assertCount(4, $frames);
+        preg_match('/"id":"([^"]+)"/', $frames[1], $partId);
+        preg_match('/"id":"([^"]+)"/', $frames[2], $firstDelta);
+        preg_match('/"id":"([^"]+)"/', $frames[3], $secondDelta);
+        $this->assertEquals($partId[1], $firstDelta[1]);
+        $this->assertEquals($partId[1], $secondDelta[1]);
+
+        // A tool call closes the open text part before its own frame.
+        $tool = $this->createMockTool('calculator', ['operation' => 'add']);
+        $toolFrames = iterator_to_array($adapter->transform(new ToolCallChunk($tool)), false);
+        $this->assertStringContainsString('"type":"text-end"', $toolFrames[0]);
+        $this->assertStringContainsString('"id":"' . $partId[1] . '"', $toolFrames[0]);
+        $this->assertStringContainsString('"type":"tool-input-available"', $toolFrames[1]);
+
+        // A new text part after the tool call gets a NEW id.
+        $reopened = iterator_to_array($adapter->transform(new TextChunk('msg_123', 'Done.')), false);
+        $this->assertStringContainsString('"type":"text-start"', $reopened[0]);
+        preg_match('/"id":"([^"]+)"/', $reopened[0], $newPartId);
+        $this->assertNotEquals($partId[1], $newPartId[1]);
+
+        // end() closes a still-open text part before finish.
+        $endFrames = iterator_to_array($adapter->end(), false);
+        $this->assertStringContainsString('"type":"text-end"', $endFrames[0]);
+        $this->assertStringContainsString('"type":"finish"', $endFrames[1]);
+        $this->assertStringContainsString('[DONE]', $endFrames[2]);
     }
 
     public function test_transform_reasoning_chunk(): void


### PR DESCRIPTION
## The problem

The Vercel AI SDK UI message stream protocol requires every delta of one text part to share a single `id`, framed by `text-start` … `text-end`: https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol#text-parts

`VercelAIAdapter` currently emits each `text-delta` with a freshly generated `id` and never sends the start/end frames. An AI SDK v5+/v6 `useChat` client receives a sequence of unrelated one-fragment parts it cannot assemble, so the streamed text never renders. (Same category as the AG-UI protocol-compliance fix in #608, for the Vercel adapter.)

## The fix

- open a text part on the first delta (`text-start`) and reuse its id for every `text-delta` of that part
- close the open part (`text-end`) before any non-text part begins (tool call, reasoning), so a tool call mid-reply is bracketed correctly
- close a still-open part in `end()` before `finish`/`[DONE]`
- a new text part after a tool call gets a new id

Tool and reasoning frames are unchanged.

## Tests

`test_transform_text_chunk` updated to the framed sequence, and a new `test_text_parts_are_framed_and_share_one_id` covers the full lifecycle: shared delta ids, tool-call bracketing, a new id after reopening, and `end()` closing an open part. Adapter suite: 10 tests, 47 assertions, green.

We run this fix in production against an `ai@6` React `useChat` frontend.