### PR TITLE
Add an opt-out for the history trimmer's strict alternation validation

### DIFF
--- a/src/Chat/History/HistoryTrimmer.php
+++ b/src/Chat/History/HistoryTrimmer.php
@@ -35,8 +35,16 @@ class HistoryTrimmer implements HistoryTrimmerInterface
     protected ?int $cachedCount = null;
     protected ?string $cachedLastHash = null;
 
+    /**
+     * @param bool $strictAlternation Throw when the history does not strictly alternate
+     * user/assistant. Providers such as Anthropic accept consecutive same-role messages
+     * and merge them into one turn, and a turn that dies mid-stream (crash, closed tab)
+     * persists exactly that shape - a strict validator then rejects the session on every
+     * later message with no way to recover. Pass false to let the provider decide.
+     */
     public function __construct(
-        protected TokenCounter $tokenCounter = new TokenCounter()
+        protected TokenCounter $tokenCounter = new TokenCounter(),
+        protected bool $strictAlternation = true
     ) {
     }
 
@@ -65,7 +73,9 @@ class HistoryTrimmer implements HistoryTrimmerInterface
         $this->totalTokens = $this->calculateTotal($messages, $checkpoints, $count);
 
         if ($this->totalTokens <= $contextWindow) {
-            $this->validateAlternation($messages);
+            if ($this->strictAlternation) {
+                $this->validateAlternation($messages);
+            }
             return $messages;
         }
 
@@ -81,7 +91,9 @@ class HistoryTrimmer implements HistoryTrimmerInterface
         }
 
         // Validate alternation after trimming
-        $this->validateAlternation($messages);
+        if ($this->strictAlternation) {
+            $this->validateAlternation($messages);
+        }
 
         return $messages;
     }

--- a/tests/ChatHistory/ChatHistoryTrimmerTest.php
+++ b/tests/ChatHistory/ChatHistoryTrimmerTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace NeuronAI\Tests\ChatHistory;
 
+use NeuronAI\Chat\History\HistoryTrimmer;
 use NeuronAI\Chat\History\InMemoryChatHistory;
+use NeuronAI\Exceptions\ChatHistoryException;
 use NeuronAI\Chat\Messages\AssistantMessage;
 use NeuronAI\Chat\Messages\ToolCallMessage;
 use NeuronAI\Chat\Messages\ToolResultMessage;
@@ -260,5 +262,27 @@ class ChatHistoryTrimmerTest extends TestCase
 
             $expectingUser = !$expectingUser;
         }
+    }
+
+    public function test_strict_alternation_throws_on_consecutive_same_role_messages(): void
+    {
+        $trimmer = new HistoryTrimmer();
+
+        $this->expectException(ChatHistoryException::class);
+
+        // The persisted shape of a turn that died mid-stream: the user message was saved,
+        // the assistant reply never landed, and the user sent another message.
+        $trimmer->trim([new UserMessage('first'), new UserMessage('second')], 1000000);
+    }
+
+    public function test_lenient_alternation_passes_consecutive_same_role_messages_through(): void
+    {
+        $trimmer = new HistoryTrimmer(strictAlternation: false);
+
+        $messages = [new UserMessage('first'), new UserMessage('second')];
+
+        // Providers such as Anthropic accept and merge consecutive same-role messages;
+        // with strict validation off the trimmer defers to the provider.
+        $this->assertSame($messages, $trimmer->trim($messages, 1000000));
     }
 }


### PR DESCRIPTION
## The problem

`HistoryTrimmer::validateAlternation()` enforces strict user/assistant alternation — a stricter grammar than some providers' own. Anthropic, for example, accepts consecutive same-role messages and merges them into a single turn.

A streamed turn that dies mid-flight (provider error, process restart, closed tab) persists exactly that shape in a database-backed chat history: the user message saved, the assistant reply never written, then the user sends another message. Because the validator runs on every trim, that one dead turn then throws `ChatHistoryException` on every later message — the session is permanently unusable with no way to self-heal.

## The fix

An opt-out constructor flag, default unchanged:

```php
new HistoryTrimmer(strictAlternation: false)
```

When false, the trimmer skips alternation validation and defers to the provider, which is the authority on what it will accept. Trimming behavior itself is untouched.

## Tests

Two added: strict mode still throws on the dead-stream shape (pins the default), lenient mode passes it through to the provider. Suite green.

We run this in production against Anthropic, where the strict validator was bricking chat sessions after mid-stream deploy restarts.