### PR TITLE
Drop a trailing tool call that never received its result on history load

### DIFF
--- a/src/Chat/History/AbstractChatHistory.php
+++ b/src/Chat/History/AbstractChatHistory.php
@@ -25,6 +25,8 @@ use NeuronAI\Exceptions\ChatHistoryException;
 use NeuronAI\Tools\Tool;
 
 use function array_map;
+use function array_pop;
+use function array_values;
 use function count;
 use function end;
 use function is_array;
@@ -143,11 +145,36 @@ abstract class AbstractChatHistory implements ChatHistoryInterface
      */
     protected function deserializeMessages(array $messages): array
     {
-        return array_map(fn (array $message): Message => match ($message['type'] ?? null) {
-            'tool_call' => $this->deserializeToolCall($message),
-            'tool_call_result' => $this->deserializeToolCallResult($message),
-            default => $this->deserializeMessage($message),
-        }, $messages);
+        return $this->dropDanglingToolCall(
+            array_map(fn (array $message): Message => match ($message['type'] ?? null) {
+                'tool_call' => $this->deserializeToolCall($message),
+                'tool_call_result' => $this->deserializeToolCallResult($message),
+                default => $this->deserializeMessage($message),
+            }, $messages)
+        );
+    }
+
+    /**
+     * Drop a trailing tool call that never received its result.
+     *
+     * A streamed turn that dies between the tool call and the tool result (provider
+     * error, process restart) persists exactly that shape, and providers reject a
+     * tool call with no matching result on every subsequent request - the loaded
+     * session can never continue. The unanswered round is unwound on load so the
+     * conversation resumes from the last complete turn.
+     *
+     * @param Message[] $messages
+     * @return Message[]
+     */
+    protected function dropDanglingToolCall(array $messages): array
+    {
+        $last = end($messages);
+
+        if ($last instanceof ToolCallMessage) {
+            array_pop($messages);
+        }
+
+        return array_values($messages);
     }
 
     /**

--- a/tests/ChatHistory/DanglingToolCallTest.php
+++ b/tests/ChatHistory/DanglingToolCallTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\ChatHistory;
+
+use NeuronAI\Chat\History\FileChatHistory;
+use NeuronAI\Chat\Messages\AssistantMessage;
+use NeuronAI\Chat\Messages\ToolCallMessage;
+use NeuronAI\Chat\Messages\ToolResultMessage;
+use NeuronAI\Chat\Messages\UserMessage;
+use NeuronAI\Tools\Tool;
+use PHPUnit\Framework\TestCase;
+
+use const DIRECTORY_SEPARATOR;
+
+use function file_exists;
+use function unlink;
+
+class DanglingToolCallTest extends TestCase
+{
+    private string $file;
+
+    protected function setUp(): void
+    {
+        $this->file = __DIR__.DIRECTORY_SEPARATOR.'neuron_dangling.chat';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->file)) {
+            unlink($this->file);
+        }
+    }
+
+    public function test_a_trailing_tool_call_without_its_result_is_dropped_on_load(): void
+    {
+        $tool = Tool::make('calculator', 'A calculator');
+
+        // A streamed turn that died between the tool call and its result: the
+        // call was persisted, the result never arrived.
+        $history = new FileChatHistory(__DIR__, 'dangling');
+        $history->addMessage(new UserMessage('What is 2+2?'));
+        $history->addMessage(new ToolCallMessage(tools: [$tool]));
+
+        // A fresh instance loads the same file - the shape a new request sees.
+        $reloaded = new FileChatHistory(__DIR__, 'dangling');
+        $messages = $reloaded->getMessages();
+
+        $this->assertCount(1, $messages);
+        $this->assertInstanceOf(UserMessage::class, $messages[0]);
+    }
+
+    public function test_a_complete_tool_round_survives_the_reload(): void
+    {
+        $tool = Tool::make('calculator', 'A calculator')->setInputs(['operation' => 'add'])->setResult('4');
+
+        $history = new FileChatHistory(__DIR__, 'dangling');
+        $history->addMessage(new UserMessage('What is 2+2?'));
+        $history->addMessage(new ToolCallMessage(tools: [$tool]));
+        $history->addMessage(new ToolResultMessage(tools: [$tool]));
+        $history->addMessage(new AssistantMessage('It is 4.'));
+
+        $reloaded = new FileChatHistory(__DIR__, 'dangling');
+        $messages = $reloaded->getMessages();
+
+        $this->assertCount(4, $messages);
+        $this->assertInstanceOf(ToolCallMessage::class, $messages[1]);
+        $this->assertInstanceOf(ToolResultMessage::class, $messages[2]);
+        $this->assertInstanceOf(AssistantMessage::class, $messages[3]);
+    }
+}


### PR DESCRIPTION
## The problem

A streamed turn that dies between the tool call and the tool result (provider error, process restart, closed tab) persists a trailing `ToolCallMessage` with no matching `ToolResultMessage`. Providers reject that shape on every subsequent request — e.g. Anthropic returns 400 for a `tool_use` block with no `tool_result` — so a session loaded with that tail can never continue: every later message fails, forever.

## The fix

`AbstractChatHistory::deserializeMessages()` now unwinds the one unanswered trailing round on load, so the conversation resumes from the last complete turn. Interior and complete tool rounds are untouched. Because it lives in the shared deserialization path, every store that loads persisted history (File, Eloquent, SQL) gets the heal.

Nothing is deleted from storage — the dangling message is only excluded from the hydrated history the provider sees.

## Tests

Two added via `FileChatHistory` round-trips: a trailing unanswered call is dropped on reload; a complete call→result→answer round survives intact. ChatHistory suite green (the pre-existing `SQLChatHistoryTest` environment errors are identical on the base commit).

We run this heal in production, where mid-stream deaths were permanently bricking database-backed chat threads.