### PR TITLE
Code cleanup: simplify closure call

### DIFF
--- a/src/Workflow/Node.php
+++ b/src/Workflow/Node.php
@@ -68,7 +68,7 @@ abstract class Node implements NodeInterface
             return $result;
         }
 
-        $result = call_user_func($closure);
+        $result = $closure();
         $this->checkpoints[$name] = $result;
         return $result;
     }


### PR DESCRIPTION
Calling closures via `$closure()` is simpler and faster than `call_user_func()`.