### PR TITLE
Code cleanup: useless json_decode on empty string

### DIFF
--- a/src/Providers/Gemini/HandleStream.php
+++ b/src/Providers/Gemini/HandleStream.php
@@ -218,9 +218,7 @@ trait HandleStream
 
             if (mb_strlen($buffer) === 1 && $buffer !== '{') {
                 $buffer = '';
-            }
-
-            if (json_decode($buffer) !== null) {
+            } elseif (json_decode($buffer) !== null) {
                 return $buffer;
             }
         }


### PR DESCRIPTION
No sense to perform `if (json_decode($buffer) !== null) {` after `$buffer` is possibly set to empty string.

`json_decode()` of empty string is NULL