### PR TITLE
Code cleanup: redundant type casting

### DIFF
--- a/src/MCP/SseHttpTransport.php
+++ b/src/MCP/SseHttpTransport.php
@@ -410,7 +410,7 @@ class SseHttpTransport implements McpTransportInterface
     {
         $headerLines = [];
         foreach ($headers as $key => $value) {
-            if (strpbrk((string) $key, "\r\n") !== false || strpbrk((string) $value, "\r\n") !== false) {
+            if (strpbrk($key, "\r\n") !== false || strpbrk($value, "\r\n") !== false) {
                 throw new McpException('Header values must not contain line breaks');
             }
             $headerLines[] = "$key: $value";

--- a/src/Providers/Gemini/HandleStream.php
+++ b/src/Providers/Gemini/HandleStream.php
@@ -83,7 +83,7 @@ trait HandleStream
         while (! $stream->eof()) {
             $line = $this->readLine($stream);
 
-            if (($line = json_decode((string) $line, true)) === null) {
+            if (($line = json_decode($line, true)) === null) {
                 continue;
             }
 

--- a/src/Providers/OpenAI/Responses/HandleStream.php
+++ b/src/Providers/OpenAI/Responses/HandleStream.php
@@ -163,11 +163,11 @@ trait HandleStream
     {
         $line = $this->readLine($stream);
 
-        if (! str_starts_with((string) $line, 'data:')) {
+        if (! str_starts_with($line, 'data:')) {
             return null;
         }
 
-        $line = trim(substr((string) $line, mb_strlen('data: ')));
+        $line = trim(substr($line, mb_strlen('data: ')));
 
         if (str_contains($line, 'DONE')) {
             return null;


### PR DESCRIPTION
1. `$headers` argument of `SseHttpTransport::buildHeaderString()` is already of type `array<string, string>`
2. `$line` vars in stream handlers are always of `string` type because they are results from `HandleStream::readLine()` method which does return string:
<img width="733" height="43" alt="image" src="https://github.com/user-attachments/assets/a3d36256-ffa3-46e1-aa19-1680bf917e6b" />
