### PR TITLE
Code cleanup: condition always evaluates to TRUE

### DIFF
--- a/src/Tools/Toolkits/FileSystem/GlobPathTool.php
+++ b/src/Tools/Toolkits/FileSystem/GlobPathTool.php
@@ -97,7 +97,7 @@ class GlobPathTool extends Tool
                 $path = $directory . $separator . $item;
 
                 if (is_dir($path)) {
-                    $files = [...$files, ...$this->globRecursive($path, $pattern, $recursive)];
+                    $files = [...$files, ...$this->globRecursive($path, $pattern, true)];
                 }
             }
         }


### PR DESCRIPTION
`$recursive` is always true because is inside `if ($recursive) {`

It's simpler and cleaner to use bool.