### PR TITLE
Code cleanup: use simple type casting

### DIFF
--- a/src/Agent/HandleTools.php
+++ b/src/Agent/HandleTools.php
@@ -143,7 +143,7 @@ trait HandleTools
                     $kitGuidelines .= PHP_EOL.implode(
                         PHP_EOL.'- ',
                         array_map(
-                            fn (ToolInterface $tool): string => "{$tool->getName()}",
+                            fn (ToolInterface $tool): string => $tool->getName(),
                             $innerTools
                         )
                     );

--- a/src/RAG/VectorStore/TypesenseVectorStore.php
+++ b/src/RAG/VectorStore/TypesenseVectorStore.php
@@ -173,7 +173,7 @@ class TypesenseVectorStore implements VectorStoreInterface
             'vector_query' => 'embedding:(' . json_encode($embedding) . ')',
             'exclude_fields' => 'embedding',
             'per_page' => $this->topK,
-            'num_candidates' => max(50, intval($this->topK) * 4),
+            'num_candidates' => max(50, (int)$this->topK * 4),
         ];
 
         $searchRequests = ['searches' => [$params]];

--- a/src/Tools/Toolkits/Calculator/DivideTool.php
+++ b/src/Tools/Toolkits/Calculator/DivideTool.php
@@ -40,7 +40,7 @@ class DivideTool extends Tool
 
     public function __invoke(int|float $number1, int|float $number2): int|float|array
     {
-        if (floatval($number2) === 0.0) {
+        if ((float)$number2 === 0.0) {
             return [
                 'operation' => $this->name,
                 'error' => 'Division by zero is not allowed.',


### PR DESCRIPTION
Simple type casting is faster and cleaner.

`"{$tool->getName()}"` code is simplified to `$tool->getName()` because `getName()` returns the same string.