### PR TITLE
Code cleanup: ambiguous i modifier

### DIFF
--- a/src/Tools/Toolkits/MySQL/MySQLSelectTool.php
+++ b/src/Tools/Toolkits/MySQL/MySQLSelectTool.php
@@ -139,7 +139,7 @@ Always use backticks around identifiers that are reserved keywords.'
 
     protected function getFirstKeyword(string $query): string
     {
-        if (preg_match('/^\s*(\w+)/i', $query, $matches)) {
+        if (preg_match('/^\s*(\w+)/u', $query, $matches)) {
             return strtoupper($matches[1]);
         }
         return '';

--- a/src/Tools/Toolkits/PGSQL/PGSQLSelectTool.php
+++ b/src/Tools/Toolkits/PGSQL/PGSQLSelectTool.php
@@ -169,7 +169,7 @@ It looks like you are trying to run a write query using the read-only query tool
     protected function performAdditionalSecurityChecks(string $query): bool
     {
         // Check for semicolon followed by potential write operations
-        if (preg_match('/;\s*(?!$)/i', $query)) {
+        if (preg_match('/;\s*(?!$)/', $query)) {
             // Multiple statements detected - need to validate each one
             $statements = $this->splitStatements($query);
             foreach ($statements as $statement) {


### PR DESCRIPTION
`i` modifier is ambiguous, if a pattern doesn't contain alphabet symbols.

`\w` is case-insensitive itself.

To get the first word from SQL query, it's better to add `u` modifier to grab the first word even in UTF, 'u' add UTF support for `\w`.
Otherwise, the first word in UTF is not captured.