### PR TITLE
Allow JSON-safe metadata types

### DIFF
--- a/src/RAG/Document.php
+++ b/src/RAG/Document.php
@@ -63,7 +63,7 @@ class Document implements JsonSerializable
         return $this;
     }
 
-    public function addMetadata(string $key, string|int $value): Document
+    public function addMetadata(string $key, string|int|float|bool|array|null $value): Document
     {
         $this->metadata[$key] = $value;
         return $this;

--- a/tests/RAG/DocumentTest.php
+++ b/tests/RAG/DocumentTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\RAG;
+
+use NeuronAI\RAG\Document;
+use PHPUnit\Framework\TestCase;
+
+use function json_decode;
+use function json_encode;
+
+class DocumentTest extends TestCase
+{
+    public function test_add_metadata_accepts_json_safe_types(): void
+    {
+        $metadata = [
+            'string' => 'value',
+            'int' => 42,
+            'float' => 3.14,
+            'bool' => true,
+            'array' => ['a', 'b'],
+            'null' => null,
+        ];
+
+        $document = new Document('Hello!');
+        foreach ($metadata as $key => $value) {
+            $document->addMetadata($key, $value);
+        }
+
+        $this->assertSame($metadata, $document->metadata);
+    }
+
+    public function test_metadata_survives_json_round_trip(): void
+    {
+        $document = new Document('Hello!');
+        $document->addMetadata('string', 'value')
+            ->addMetadata('int', 42)
+            ->addMetadata('float', 3.14)
+            ->addMetadata('bool', true)
+            ->addMetadata('array', ['a', 'b'])
+            ->addMetadata('null', null);
+
+        // Vector stores persist metadata as JSON and re-add each
+        // decoded value through addMetadata() on retrieval.
+        $decoded = json_decode(json_encode($document->jsonSerialize()), true);
+
+        $hydrated = new Document($decoded['content']);
+        foreach ($decoded['metadata'] as $key => $value) {
+            $hydrated->addMetadata($key, $value);
+        }
+
+        $this->assertSame($document->metadata, $hydrated->metadata);
+    }
+}


### PR DESCRIPTION
_Some_ vector stores allow more than just `string|int` data types to be stored in the metadata. 