### PR TITLE
Accept any ObserverInterface as the default observer

### DIFF
--- a/src/Observability/EventBus.php
+++ b/src/Observability/EventBus.php
@@ -29,7 +29,7 @@ class EventBus
      */
     private static array $initialized = [];
 
-    private static ?InspectorObserver $defaultObserver = null;
+    private static ?ObserverInterface $defaultObserver = null;
 
     /**
      * Register an observer, optionally scoped to a workflow.
@@ -48,7 +48,7 @@ class EventBus
         }
     }
 
-    public static function setDefaultObserver(?InspectorObserver $observer): void
+    public static function setDefaultObserver(?ObserverInterface $observer): void
     {
         self::$defaultObserver = $observer;
     }


### PR DESCRIPTION
`EventBus` types its default-observer seam against the concrete class
`NeuronAI\Observability\InspectorObserver`:

```php
private static ?InspectorObserver $defaultObserver = null;

public static function setDefaultObserver(?InspectorObserver $observer): void
```

That class is deprecated by the library itself:

```php
/**
 * @deprecated Use the new observer from the Inspector PHP package - Inspector/Neuron/InspectorObserver
 */
class InspectorObserver extends \Inspector\Neuron\InspectorObserver
```

Since the deprecated class is a **subclass** of the recommended one, a parameter typed against it does
not accept the recommended one. Following the deprecation notice therefore makes an observer
*ineligible* for `setDefaultObserver()`, and the only way to install a default observer today is to
extend a class documented as going away.

### Why a default observer is worth installing

`emit()` routes either/or: an event carrying a `workflowId` reaches only the observers registered for
that workflow, and `WorkflowExecutor::run()` always sets one. An application therefore cannot observe
workflows that never called `observe()` themselves. The one lever is the fallback in `emit()`:

```php
if (!isset(self::$initialized[$scope]) || !self::$initialized[$scope]) {
    self::observe(self::$defaultObserver ?? InspectorObserver::instance(), $workflowId);
}
```

We use it for cost metering: an observer that has to see agent code written without knowing about it.
Nothing about that job involves Inspector.

### The change

Type the property and the parameter against `ObserverInterface`. Two lines.

Why it is safe:

- `observe()` already takes `ObserverInterface`, and `emit()` passes the default observer straight to
  it, so the widened type is what the value is used as anyway.
- Widening a parameter type is backward compatible: every existing caller still type-checks, and the
  method is static, so there is no inheritance contract to break.
- Nothing inside the library calls `setDefaultObserver()`; it exists purely as public API.
- `InspectorObserver::instance()` stays the fallback in `emit()` and keeps working, since it
  implements `ObserverInterface`.
