### PR TITLE
feat: add OrcaRouter provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Supported providers:
 - [Mistral](https://docs.neuron-ai.dev/providers/ai-provider#mistral)
 - [HuggingFace](https://docs.neuron-ai.dev/providers/ai-provider#huggingface)
 - [Deepseek](https://docs.neuron-ai.dev/providers/ai-provider#deepseek)
+- [OrcaRouter](https://www.orcarouter.ai) (OpenAI compatible AI gateway)
 - [Grok](https://docs.neuron-ai.dev/providers/ai-provider#grok-x-ai)
 - [AWS Bedrock Runtime](https://docs.neuron-ai.dev/providers/ai-provider#aws-bedrock-runtime)
 - [Cohere](https://docs.neuron-ai.dev/providers/ai-provider#cohere)

--- a/src/Providers/AGENTS.md
+++ b/src/Providers/AGENTS.md
@@ -24,6 +24,7 @@ interface AIProviderInterface {
 | `Ollama/` | Local models |
 | `Mistral/` | Mistral AI |
 | `Deepseek/` | Deepseek |
+| `OrcaRouter/` | OrcaRouter |
 | `Cohere/` | Cohere |
 | `HuggingFace/` | Hugging Face |
 | `XAI/` | xAI Grok |

--- a/src/Providers/OrcaRouter/OrcaRouter.php
+++ b/src/Providers/OrcaRouter/OrcaRouter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Providers\OrcaRouter;
+
+use NeuronAI\Providers\OpenAI\OpenAI;
+
+class OrcaRouter extends OpenAI
+{
+    protected string $baseUri = 'https://api.orcarouter.ai/v1';
+}

--- a/tests/Providers/OrcaRouterTest.php
+++ b/tests/Providers/OrcaRouterTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\Providers;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use NeuronAI\Chat\Messages\AssistantMessage;
+use NeuronAI\Chat\Messages\UserMessage;
+use NeuronAI\HttpClient\GuzzleHttpClient;
+use NeuronAI\Providers\OrcaRouter\OrcaRouter;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+use function json_decode;
+
+class OrcaRouterTest extends TestCase
+{
+    protected string $body = '{"model": "grok-4","choices":[{"index": 0,"finish_reason": "stop","message": {"role": "assistant","content": "test response"}}],"usage": {"prompt_tokens": 19,"completion_tokens": 10,"total_tokens": 29}}';
+
+    public function test_base_uri(): void
+    {
+        $provider = new OrcaRouter('', 'grok-4');
+        $reflection = new ReflectionClass($provider);
+        $property = $reflection->getProperty('baseUri');
+        $this->assertSame('https://api.orcarouter.ai/v1', $property->getValue($provider));
+    }
+
+    public function test_chat_request(): void
+    {
+        $sentRequests = [];
+        $history = Middleware::history($sentRequests);
+        $mockHandler = new MockHandler([
+            new Response(status: 200, body: $this->body),
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+        $stack->push($history);
+
+        $provider = (new OrcaRouter('', 'grok-4'))->setHttpClient(new GuzzleHttpClient(handler: $stack));
+
+        $response = $provider->chat(new UserMessage('Hi'));
+        $this->assertInstanceOf(AssistantMessage::class, $response);
+
+        // Ensure we sent one request.
+        $this->assertCount(1, $sentRequests);
+        $request = $sentRequests[0];
+
+        // Ensure we have sent the expected request payload.
+        $expectedRequest = [
+            'model' => 'grok-4',
+            'messages' => [
+                [
+                    'role' => 'user',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'text' => 'Hi',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expectedRequest, json_decode((string) $request['request']->getBody()->getContents(), true));
+        $this->assertSame('test response', $response->getContent());
+        $this->assertSame('stop', $response->stopReason());
+    }
+}


### PR DESCRIPTION
## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Description

Neuron users can now point their agent at [OrcaRouter](https://www.orcarouter.ai) with a single line of code, exactly like the existing Deepseek or Grok providers, instead of treating it as an anonymous custom base URL.

**What does this PR do?**

Adds `NeuronAI\Providers\OrcaRouter\OrcaRouter` as a first-class provider. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

**Why is this change needed?**

The provider mirrors how the existing OpenAI-compatible providers are wired: `OrcaRouter` extends `NeuronAI\Providers\OpenAI\OpenAI` and only overrides the base URI, following the same pattern as `XAI\Grok`. The README provider list and the `src/Providers/AGENTS.md` provider table are updated so the provider is discoverable.

**How does this change should be used and documented?**

```php
use NeuronAI\Providers\OrcaRouter\OrcaRouter;

protected function provider(): AIProviderInterface
{
    return new OrcaRouter(
        key: 'ORCAROUTER_API_KEY',
        model: 'openai/gpt-4o-mini',
    );
}
```

## Related Issues

-

## Testing

- [x] I have tested this change locally
- [x] I have added/updated unit tests where appropriate
- [x] All existing tests pass
- [ ] I have tested this with different PHP versions (if applicable)

Added `tests/Providers/OrcaRouterTest.php` covering the chat request payload and the provider base URI. Ran the full suite (1216 tests, 5043 assertions, OK), `phpstan analyse` (level 5, no errors) and `php-cs-fixer` on the new files. Also verified the new provider against the live OrcaRouter endpoint (HTTP 200) using a real key.

## Breaking Changes

- [x] No breaking changes

## Documentation

- [x] No documentation changes needed
- [x] I have updated relevant documentation

## Checklist

- [x] My code follows the project's coding standards (PHPStan)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] My commit messages are clear and descriptive
- [x] This PR addresses only ONE specific goal/issue

## Additional Notes

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
