### PR TITLE
fix(structured): a text-less completion goes through the retry loop instead of raising a TypeError

### DIFF
--- a/src/Agent/Nodes/StructuredOutputNode.php
+++ b/src/Agent/Nodes/StructuredOutputNode.php
@@ -144,7 +144,9 @@ class StructuredOutputNode extends InferenceNode
     ): object {
         // Extract a valid JSON object from the LLM response
         $this->emit('structured-extracting', new Extracting($response));
-        $json = (new JsonExtractor())->getJson($response->getContent());
+        // A completion without text blocks yields a null content: treat it as an
+        // extraction failure so it goes through the retry loop instead of a TypeError.
+        $json = (new JsonExtractor())->getJson($response->getContent() ?? '');
         $this->emit('structured-extracted', new Extracted($response, $schema, $json));
         if ($json === null || $json === '') {
             throw new AgentException("The response does not contains a valid JSON Object.");

--- a/tests/Agent/AgentTest.php
+++ b/tests/Agent/AgentTest.php
@@ -128,6 +128,30 @@ class AgentTest extends TestCase
         $provider->assertMethodCallCount('structured', 1);
     }
 
+    public function test_structured_output_retries_when_the_response_has_no_text(): void
+    {
+        // A completion without text blocks (content filtered, max_tokens spent on
+        // reasoning, reasoning-only answer) makes getContent() return null: it must
+        // go through the retry loop like any other extraction failure instead of
+        // escaping it as a TypeError from JsonExtractor::getJson().
+        $provider = new FakeAIProvider(
+            new AssistantMessage([]),
+            new AssistantMessage('{"name": "Alice"}'),
+        );
+
+        $agent = Agent::make();
+        $agent->setAiProvider($provider);
+
+        $user = $agent->structured(
+            new UserMessage('Generate a user'),
+            User::class
+        );
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertSame('Alice', $user->name);
+        $provider->assertMethodCallCount('structured', 2);
+    }
+
     public function test_failed_chat_does_not_persist_inbound_message(): void
     {
         $history = new InMemoryChatHistory();


### PR DESCRIPTION
Fixes #644 (same trace as #305).

`StructuredOutputNode::processResponse()` passed `Message::getContent()` (`?string`) straight into `JsonExtractor::getJson(string)`. A completion with no text block — content filtered, `max_tokens` spent on reasoning, a reasoning-only answer — returns `null` there, and under `strict_types` that raised a `TypeError` that the retry loop (`catch AgentException|DeserializerException`) never sees, so the very first empty response aborted the structured call.

The fix coalesces the null to an empty string: `getJson('')` returns `null`, `processResponse()` turns that into the usual `AgentException("The response does not contains a valid JSON Object.")`, and the node re-prompts like it does for any other invalid output.

Test: `test_structured_output_retries_when_the_response_has_no_text` — a `FakeAIProvider` answering first with `new AssistantMessage([])` and then with valid JSON; fails with the TypeError before the change, passes after.
