### PR TITLE
Replace retired claude-3-5-sonnet-20241022 in two skill files

### DIFF
--- a/skills/neuron-agent-builder/SKILL.md
+++ b/skills/neuron-agent-builder/SKILL.md
@@ -141,7 +141,7 @@ $person = $agent->structured(
 ```php
 new Anthropic(
     key: $_ENV['ANTHROPIC_API_KEY'],
-    model: 'claude-3-5-sonnet-20241022',
+    model: 'claude-sonnet-5',
 )
 ```
 

--- a/skills/neuron-rag-specialist/SKILL.md
+++ b/skills/neuron-rag-specialist/SKILL.md
@@ -30,7 +30,7 @@ class MyChatBot extends RAG
     {
         return new Anthropic(
             key: $_ENV['ANTHROPIC_API_KEY'],
-            model: 'claude-3-5-sonnet-20241022',
+            model: 'claude-sonnet-5',
         );
     }
 


### PR DESCRIPTION
Two skill files hand Claude a model id that the API stopped serving on 28 October 2025.

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `skills/neuron-rag-specialist/SKILL.md` | 33 | `claude-3-5-sonnet-20241022` | `claude-sonnet-5` |
| `skills/neuron-agent-builder/SKILL.md` | 144 | `claude-3-5-sonnet-20241022` | `claude-sonnet-5` |

Both are the Anthropic provider snippet a skill tells Claude to copy, so the id lands in whatever agent the user is building. Retirement dates are on the [model deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations).

Left alone on purpose:

The test fixtures under `tests/Providers/` pin `claude-3-7-sonnet-latest` in mocked response bodies. Those strings are assertions about wire format, not model choices, and rewriting them would only churn the suite.

The `examples/` directory carries retired ids as well, `claude-3-7-sonnet-latest` in eight files and both `claude-3-5-sonnet-20241022` and `claude-3-5-haiku-20241022` in `examples/agent/summarization.php`. I kept this pull request to the skills because that is one concern and one review. Say the word and I will send the examples separately, or you may prefer to sweep them yourself.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not run anything against the API to reproduce a failure, the claim rests on the published retirement date. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
