### PR TITLE
Add AG-UI run error termination

### DIFF
--- a/src/Chat/Messages/Stream/Adapters/AGUIAdapter.php
+++ b/src/Chat/Messages/Stream/Adapters/AGUIAdapter.php
@@ -38,8 +38,6 @@ class AGUIAdapter extends SSEAdapter
 
     protected ?string $reasoningMessageId = null;
 
-    protected bool $runTerminated = false;
-
     /**
      * @param string|null $threadId Optional thread ID for conversation context
      * @param string|null $runId Optional run ID, echoed back to the client as required by the protocol
@@ -268,9 +266,7 @@ class AGUIAdapter extends SSEAdapter
         }
 
         // Emit RunFinished event
-        if ($this->runId !== null && !$this->runTerminated) {
-            $this->runTerminated = true;
-
+        if ($this->runId !== null) {
             yield $this->sse([
                 'type' => 'RUN_FINISHED',
                 'threadId' => $this->threadId,
@@ -286,10 +282,6 @@ class AGUIAdapter extends SSEAdapter
      */
     public function error(string $message, ?string $code = null): iterable
     {
-        if ($this->runTerminated) {
-            return;
-        }
-
         foreach ($this->endReasoning() as $event) {
             yield $event;
         }
@@ -305,8 +297,6 @@ class AGUIAdapter extends SSEAdapter
         if ($code !== null) {
             $event['code'] = $code;
         }
-
-        $this->runTerminated = true;
 
         yield $this->sse($event);
     }

--- a/src/Chat/Messages/Stream/Adapters/AGUIAdapter.php
+++ b/src/Chat/Messages/Stream/Adapters/AGUIAdapter.php
@@ -38,6 +38,8 @@ class AGUIAdapter extends SSEAdapter
 
     protected ?string $reasoningMessageId = null;
 
+    protected bool $runTerminated = false;
+
     /**
      * @param string|null $threadId Optional thread ID for conversation context
      * @param string|null $runId Optional run ID, echoed back to the client as required by the protocol
@@ -266,12 +268,46 @@ class AGUIAdapter extends SSEAdapter
         }
 
         // Emit RunFinished event
-        if ($this->runId !== null) {
+        if ($this->runId !== null && !$this->runTerminated) {
+            $this->runTerminated = true;
+
             yield $this->sse([
                 'type' => 'RUN_FINISHED',
                 'threadId' => $this->threadId,
                 'runId' => $this->runId,
             ]);
         }
+    }
+
+    /**
+     * Terminate the run with an AG-UI error instead of a successful result.
+     *
+     * @return iterable<string>
+     */
+    public function error(string $message, ?string $code = null): iterable
+    {
+        if ($this->runTerminated) {
+            return;
+        }
+
+        foreach ($this->endReasoning() as $event) {
+            yield $event;
+        }
+        foreach ($this->endText() as $event) {
+            yield $event;
+        }
+
+        $event = [
+            'type' => 'RUN_ERROR',
+            'message' => $message,
+        ];
+
+        if ($code !== null) {
+            $event['code'] = $code;
+        }
+
+        $this->runTerminated = true;
+
+        yield $this->sse($event);
     }
 }

--- a/tests/Adapters/AgUIProtocolComplianceTest.php
+++ b/tests/Adapters/AgUIProtocolComplianceTest.php
@@ -42,6 +42,7 @@ class AgUIProtocolComplianceTest extends TestCase
     private const REQUIRED_FIELDS = [
         'RUN_STARTED' => ['runId', 'threadId'],
         'RUN_FINISHED' => ['runId', 'threadId'],
+        'RUN_ERROR' => ['message'],
         'TEXT_MESSAGE_START' => ['messageId', 'role'],
         'TEXT_MESSAGE_CONTENT' => ['messageId', 'delta'],
         'TEXT_MESSAGE_END' => ['messageId'],
@@ -173,6 +174,52 @@ class AgUIProtocolComplianceTest extends TestCase
         $this->assertSame('run_custom', $last['runId']);
     }
 
+    public function test_error_closes_an_open_text_message_and_terminates_the_run(): void
+    {
+        $adapter = new AGUIAdapter('thread_custom', 'run_custom');
+
+        $events = $this->collect(
+            $adapter->start(),
+            $adapter->transform(new TextChunk('msg_1', 'Partial answer')),
+            $adapter->error('The provider failed.', 'provider_error'),
+            $adapter->end(),
+        );
+
+        $this->assertCompliant($events);
+        $this->assertSame(
+            ['RUN_STARTED', 'TEXT_MESSAGE_START', 'TEXT_MESSAGE_CONTENT', 'TEXT_MESSAGE_END', 'RUN_ERROR'],
+            array_column($events, 'type'),
+        );
+        $this->assertSame('The provider failed.', $events[array_key_last($events)]['message']);
+        $this->assertSame('provider_error', $events[array_key_last($events)]['code']);
+    }
+
+    public function test_error_closes_an_open_reasoning_message(): void
+    {
+        $adapter = new AGUIAdapter();
+
+        $events = $this->collect(
+            $adapter->start(),
+            $adapter->transform(new ReasoningChunk('reason_1', 'Partial reasoning')),
+            $adapter->error('The provider failed.'),
+        );
+
+        $this->assertCompliant($events);
+        $this->assertSame(
+            [
+                'RUN_STARTED',
+                'REASONING_START',
+                'REASONING_MESSAGE_START',
+                'REASONING_MESSAGE_CONTENT',
+                'REASONING_MESSAGE_END',
+                'REASONING_END',
+                'RUN_ERROR',
+            ],
+            array_column($events, 'type'),
+        );
+        $this->assertArrayNotHasKey('code', $events[array_key_last($events)]);
+    }
+
     /**
      * Parse SSE frames into decoded event payloads.
      *
@@ -209,7 +256,11 @@ class AgUIProtocolComplianceTest extends TestCase
 
         $first = $events[0];
         $this->assertSame('RUN_STARTED', $first['type'], 'First event must be RUN_STARTED');
-        $this->assertSame('RUN_FINISHED', $events[array_key_last($events)]['type'], 'Last event must be RUN_FINISHED');
+        $this->assertContains(
+            $events[array_key_last($events)]['type'],
+            ['RUN_FINISHED', 'RUN_ERROR'],
+            'Last event must terminate the run',
+        );
 
         $openText = null;
         $openReasoning = null;
@@ -237,6 +288,11 @@ class AgUIProtocolComplianceTest extends TestCase
                 case 'RUN_FINISHED':
                     $this->assertSame($runId, $event['runId'], 'RUN_FINISHED.runId must match RUN_STARTED');
                     $this->assertSame($threadId, $event['threadId'], 'RUN_FINISHED.threadId must match RUN_STARTED');
+                    break;
+
+                case 'RUN_ERROR':
+                    $this->assertIsString($event['message']);
+                    $this->assertNotSame('', $event['message']);
                     break;
 
                 case 'TEXT_MESSAGE_START':

--- a/tests/Adapters/AgUIProtocolComplianceTest.php
+++ b/tests/Adapters/AgUIProtocolComplianceTest.php
@@ -182,7 +182,6 @@ class AgUIProtocolComplianceTest extends TestCase
             $adapter->start(),
             $adapter->transform(new TextChunk('msg_1', 'Partial answer')),
             $adapter->error('The provider failed.', 'provider_error'),
-            $adapter->end(),
         );
 
         $this->assertCompliant($events);


### PR DESCRIPTION
## Summary

- add `AGUIAdapter::error()` for emitting a `RUN_ERROR` event
- close active text or reasoning streams before emitting the error
- support the optional AG-UI error code

## Why

`AGUIAdapter` currently supports `RUN_FINISHED`, but does not expose a way to
report a failed run through the corresponding AG-UI `RUN_ERROR` event.

Applications therefore need to subclass the adapter and expose its protected
stream-closing and SSE-formatting methods.

The emitted event follows the official AG-UI schema, with a required `message`
and an optional `code`.

## Protocol reference

- [`RunError` lifecycle event](https://docs.ag-ui.com/concepts/events#runerror)
- [`RunErrorEvent` schema](https://docs.ag-ui.com/sdk/js/core/events#runerrorevent)

## Testing

- `vendor/bin/phpunit tests/Adapters/AgUIProtocolComplianceTest.php`
- `composer analyse`