### PR TITLE
fix(aws): keep redacted reasoning blocks so the next request isn't rejected

### DIFF
--- a/src/Chat/Enums/ContentBlockType.php
+++ b/src/Chat/Enums/ContentBlockType.php
@@ -8,6 +8,7 @@ enum ContentBlockType: string
 {
     case TEXT = 'text';
     case REASONING = 'reasoning';
+    case REDACTED_REASONING = 'redacted_reasoning';
     case IMAGE = 'image';
     case FILE = 'file';
     case AUDIO = 'audio';

--- a/src/Chat/History/AbstractChatHistory.php
+++ b/src/Chat/History/AbstractChatHistory.php
@@ -14,6 +14,7 @@ use NeuronAI\Chat\Messages\ContentBlocks\ContentBlockInterface;
 use NeuronAI\Chat\Messages\ContentBlocks\FileContent;
 use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
 use NeuronAI\Chat\Messages\ContentBlocks\ReasoningContent;
+use NeuronAI\Chat\Messages\ContentBlocks\RedactedReasoningContent;
 use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
 use NeuronAI\Chat\Messages\ContentBlocks\VideoContent;
 use NeuronAI\Chat\Messages\Message;
@@ -258,6 +259,9 @@ abstract class AbstractChatHistory implements ChatHistoryInterface
             ContentBlockType::REASONING => new ReasoningContent(
                 content: $block['content'],
                 id: $block['id'] ?? null
+            ),
+            ContentBlockType::REDACTED_REASONING => new RedactedReasoningContent(
+                content: $block['content']
             ),
             ContentBlockType::IMAGE => new ImageContent(
                 content: $block['content'],

--- a/src/Chat/Messages/ContentBlocks/RedactedReasoningContent.php
+++ b/src/Chat/Messages/ContentBlocks/RedactedReasoningContent.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Chat\Messages\ContentBlocks;
+
+use NeuronAI\Chat\Enums\ContentBlockType;
+
+class RedactedReasoningContent extends ContentBlock
+{
+    public function getType(): ContentBlockType
+    {
+        return ContentBlockType::REDACTED_REASONING;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->getType(),
+            'content' => $this->content,
+            'meta' => $this->meta,
+        ];
+    }
+}

--- a/src/Providers/AWS/HandleChat.php
+++ b/src/Providers/AWS/HandleChat.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use NeuronAI\Chat\Messages\AssistantMessage;
 use NeuronAI\Chat\Messages\ContentBlocks\ContentBlockInterface;
 use NeuronAI\Chat\Messages\ContentBlocks\ReasoningContent;
+use NeuronAI\Chat\Messages\ContentBlocks\RedactedReasoningContent;
 use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
 use NeuronAI\Chat\Messages\Message;
 use NeuronAI\Chat\Messages\ToolCallMessage;
@@ -86,6 +87,10 @@ trait HandleChat
                     $reasoningText['text'],
                     $reasoningText['signature'] ?? null,
                 );
+            }
+
+            if (isset($content['reasoningContent']['redactedContent'])) {
+                $blocks[] = new RedactedReasoningContent($content['reasoningContent']['redactedContent']);
             }
         }
 

--- a/src/Providers/AWS/HandleStream.php
+++ b/src/Providers/AWS/HandleStream.php
@@ -8,6 +8,7 @@ use Aws\Api\Parser\EventParsingIterator;
 use Generator;
 use NeuronAI\Chat\Messages\AssistantMessage;
 use NeuronAI\Chat\Messages\ContentBlocks\ReasoningContent;
+use NeuronAI\Chat\Messages\ContentBlocks\RedactedReasoningContent;
 use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
 use NeuronAI\Chat\Messages\Message;
 use NeuronAI\Chat\Messages\Stream\Chunks\ReasoningChunk;
@@ -86,6 +87,13 @@ trait HandleStream
 
                     if (isset($reasoningContent['signature'])) {
                         $this->streamState->signReasoningContentBlock($contentBlockIndex, $reasoningContent['signature']);
+                    }
+
+                    if (isset($reasoningContent['redactedContent'])) {
+                        $this->streamState->updateContentBlock(
+                            $contentBlockIndex,
+                            new RedactedReasoningContent($reasoningContent['redactedContent'])
+                        );
                     }
 
                     continue;

--- a/src/Providers/AWS/MessageMapper.php
+++ b/src/Providers/AWS/MessageMapper.php
@@ -11,6 +11,7 @@ use NeuronAI\Chat\Messages\ContentBlocks\ContentBlockInterface;
 use NeuronAI\Chat\Messages\ContentBlocks\FileContent;
 use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
 use NeuronAI\Chat\Messages\ContentBlocks\ReasoningContent;
+use NeuronAI\Chat\Messages\ContentBlocks\RedactedReasoningContent;
 use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
 use NeuronAI\Chat\Messages\ContentBlocks\VideoContent;
 use NeuronAI\Chat\Messages\Message;
@@ -123,6 +124,11 @@ class MessageMapper implements MessageMapperInterface
                         'text' => $block->content,
                         ...($block->id === null ? [] : ['signature' => $block->id]),
                     ],
+                ],
+            ],
+            RedactedReasoningContent::class => [
+                'reasoningContent' => [
+                    'redactedContent' => $block->content,
                 ],
             ],
             TextContent::class => ['text' => $block->content],

--- a/tests/ChatHistory/ContentBlockDeserializationTest.php
+++ b/tests/ChatHistory/ContentBlockDeserializationTest.php
@@ -10,6 +10,7 @@ use NeuronAI\Chat\Messages\AssistantMessage;
 use NeuronAI\Chat\Messages\ContentBlocks\AudioContent;
 use NeuronAI\Chat\Messages\ContentBlocks\FileContent;
 use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
+use NeuronAI\Chat\Messages\ContentBlocks\RedactedReasoningContent;
 use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
 use NeuronAI\Chat\Messages\ContentBlocks\VideoContent;
 use NeuronAI\Chat\Messages\UserMessage;
@@ -221,6 +222,38 @@ class ContentBlockDeserializationTest extends TestCase
 
         $this->assertInstanceOf(VideoContent::class, $contentBlocks[4]);
         $this->assertEquals('https://example.com/video.mp4', $contentBlocks[4]->content);
+    }
+
+    public function test_redacted_reasoning_block_survives_the_history_round_trip(): void
+    {
+        $key = 'test_redacted_reasoning';
+        $filePath = $this->testDir . '/neuron_' . $key . '.chat';
+
+        $data = [
+            [
+                'role' => 'assistant',
+                'content' => [
+                    [
+                        'type' => 'redacted_reasoning',
+                        'content' => 'encrypted',
+                    ],
+                    [
+                        'type' => 'text',
+                        'content' => 'The answer',
+                    ],
+                ],
+            ],
+        ];
+
+        file_put_contents($filePath, json_encode($data));
+
+        $history = new FileChatHistory($this->testDir, $key);
+        $contentBlocks = $history->getMessages()[0]->getContentBlocks();
+
+        $this->assertCount(2, $contentBlocks);
+        $this->assertInstanceOf(RedactedReasoningContent::class, $contentBlocks[0]);
+        $this->assertEquals('encrypted', $contentBlocks[0]->content);
+        $this->assertInstanceOf(TextContent::class, $contentBlocks[1]);
     }
 
     public function test_mixed_messages_with_content_blocks(): void

--- a/tests/Providers/BedrockReasoningTest.php
+++ b/tests/Providers/BedrockReasoningTest.php
@@ -10,6 +10,7 @@ use Aws\Result;
 use GuzzleHttp\Promise\FulfilledPromise;
 use NeuronAI\Chat\Messages\AssistantMessage;
 use NeuronAI\Chat\Messages\ContentBlocks\ReasoningContent;
+use NeuronAI\Chat\Messages\ContentBlocks\RedactedReasoningContent;
 use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
 use NeuronAI\Chat\Messages\Stream\Chunks\ReasoningChunk;
 use NeuronAI\Chat\Messages\Stream\Chunks\TextChunk;
@@ -45,13 +46,13 @@ class BedrockReasoningTest extends TestCase
             ],
             [
                 'contentBlockDelta' => [
-                    'contentBlockIndex' => 0,
+                    'contentBlockIndex' => 1,
                     'delta' => ['reasoningContent' => ['redactedContent' => 'encrypted']],
                 ],
             ],
             [
                 'contentBlockDelta' => [
-                    'contentBlockIndex' => 1,
+                    'contentBlockIndex' => 2,
                     'delta' => ['text' => 'The answer'],
                 ],
             ],
@@ -84,12 +85,14 @@ class BedrockReasoningTest extends TestCase
 
         $blocks = $message->getContentBlocks();
 
-        $this->assertCount(2, $blocks);
+        $this->assertCount(3, $blocks);
         $this->assertInstanceOf(ReasoningContent::class, $blocks[0]);
         $this->assertSame('Let me think', $blocks[0]->content);
         $this->assertSame('sig-123', $blocks[0]->id);
-        $this->assertInstanceOf(TextContent::class, $blocks[1]);
-        $this->assertSame('The answer', $blocks[1]->content);
+        $this->assertInstanceOf(RedactedReasoningContent::class, $blocks[1]);
+        $this->assertSame('encrypted', $blocks[1]->content);
+        $this->assertInstanceOf(TextContent::class, $blocks[2]);
+        $this->assertSame('The answer', $blocks[2]->content);
         $this->assertSame(10, $message->getUsage()->inputTokens);
         $this->assertSame(8, $message->getUsage()->outputTokens);
     }
@@ -137,11 +140,12 @@ class BedrockReasoningTest extends TestCase
 
         $blocks = $message->getContentBlocks();
 
-        $this->assertCount(2, $blocks);
+        $this->assertCount(3, $blocks);
         $this->assertInstanceOf(ReasoningContent::class, $blocks[0]);
         $this->assertSame('Let me think', $blocks[0]->content);
         $this->assertSame('sig-123', $blocks[0]->id);
-        $this->assertInstanceOf(TextContent::class, $blocks[1]);
+        $this->assertInstanceOf(RedactedReasoningContent::class, $blocks[1]);
+        $this->assertInstanceOf(TextContent::class, $blocks[2]);
 
         $this->assertSame([
             [
@@ -153,6 +157,11 @@ class BedrockReasoningTest extends TestCase
                                 'text' => 'Let me think',
                                 'signature' => 'sig-123',
                             ],
+                        ],
+                    ],
+                    [
+                        'reasoningContent' => [
+                            'redactedContent' => 'encrypted',
                         ],
                     ],
                     ['text' => 'The answer'],


### PR DESCRIPTION
Follow-up to #643, as discussed there.

## Problem

Bedrock's `ReasoningContentBlock` is a union: a block carries either `reasoningText` (`text` + `signature`) or `redactedContent`, the encrypted blob a Claude model returns when its thinking is redacted. 3.16.8 fixed the `reasoningText` half; the blob is still dropped in `HandleStream`, in `HandleChat::mapResponseContent()` and, consequently, in `MessageMapper`.

Anthropic requires the thinking blocks of the *latest* assistant message to be echoed back unmodified — redacted ones included — or the request is rejected:

> Within the latest assistant message, the sequence of consecutive `thinking` blocks must match what the model generated in the original request: you can't rearrange, edit, or partially drop them. This includes `redacted_thinking` blocks.

([Preserving thinking blocks](https://platform.claude.com/docs/en/build-with-claude/thinking#preserving-thinking-blocks), [the matching 400](https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting#error-thinking-blocks-modified), [Bedrock's union](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlock.html))

It bites on a tool-use turn that happened to get a redacted block, where the assistant turn has to be replayed alongside the tool result.

## Solution

`RedactedReasoningContent` keeps the blob on a content block, and `MessageMapper` sends it back as `['reasoningContent' => ['redactedContent' => $blob]]`.

| File | Change |
|---|---|
| `Chat/Messages/ContentBlocks/RedactedReasoningContent.php` | new block, mirrors `TextContent` |
| `Chat/Enums/ContentBlockType.php` | `REDACTED_REASONING` case |
| `Chat/History/AbstractChatHistory.php` | deserialization arm — without it the block doesn't survive the history, which is the turn where it matters |
| `Providers/AWS/HandleStream.php` | third branch next to `text` and `signature` |
| `Providers/AWS/HandleChat.php` | same on the non-streaming response |
| `Providers/AWS/MessageMapper.php` | map it back |

## Design notes

- **The new block extends `ContentBlock`, not `TextContent` or `ReasoningContent`.** The blob is not readable text: staying out of those two hierarchies keeps it out of `Message::getContent()`, `getTextBlocks()` and `getReasoning()`, which all filter on them. The cost is that `TokenCounter` falls to its `default` arm (flat ~100 tokens) instead of counting the blob's characters — which seemed the more honest estimate anyway, but say the word and I'll add an explicit arm.
- **No `ReasoningChunk` is yielded** for a redacted delta: there is nothing displayable in it.
- **Other providers are unchanged.** Their mappers hit `default => null` for the new block, i.e. they keep dropping it exactly as today. The Anthropic provider has the same gap (`redacted_thinking` is dropped in its `HandleChat`/`HandleStream`) — happy to send a separate PR if you want it closed too.
- **One existing test moved an index.** In `BedrockReasoningTest` the `redactedContent` delta sat on `contentBlockIndex` 0, the same block as the reasoning text; it now has its own index, because the delta union is per content block and Converse gives each one its own. Left on the shared index, `updateContentBlock()` would concatenate the blob onto the reasoning text.

## Tests

- `BedrockReasoningTest`: both cases now assert the redacted block survives, and that the mapper emits it back between `reasoningText` and `text`.
- `ContentBlockDeserializationTest`: a round trip through the chat history, which is the path that carries the block to the next request.
- `vendor/bin/phpunit` → 1224 tests green (the 7 `WeaviateTest` errors are the service not running locally, unrelated).
- `composer analyse` → no errors. `php-cs-fixer --dry-run` → clean on the touched files.