### PR TITLE
Allow child process initialization for parallel tools

### DIFF
--- a/src/Agent/Agent.php
+++ b/src/Agent/Agent.php
@@ -21,6 +21,7 @@ use NeuronAI\Workflow\Persistence\PersistenceInterface;
 use NeuronAI\Workflow\Workflow;
 use NeuronAI\Workflow\WorkflowHandlerInterface;
 use NeuronAI\Workflow\WorkflowState;
+use Closure;
 use Throwable;
 
 use function is_array;
@@ -41,6 +42,8 @@ class Agent extends Workflow implements AgentInterface
 
     protected bool $parallelToolCalls = false;
 
+    protected ?Closure $beforeParallelToolChild = null;
+
     public function init(?InterruptRequest $resumeRequest = null): WorkflowHandlerInterface
     {
         $this->resolveState()->resetToolRuns();
@@ -50,14 +53,18 @@ class Agent extends Workflow implements AgentInterface
     }
 
     /**
-     * Determines whether tools should be executed in parallel.
-     * Override this method to return true to enable parallel tool execution.
+     * Determines whether tools should be executed in parallel and optionally
+     * configures a callback to initialize resources in each child process.
      *
      * Note: Parallel execution requires the pcntl extension and spatie/fork package.
      */
-    public function parallelToolCalls(bool $enabled): AgentInterface
+    public function parallelToolCalls(bool $enabled, ?callable $beforeChild = null): AgentInterface
     {
         $this->parallelToolCalls = $enabled;
+        $this->beforeParallelToolChild = $beforeChild !== null
+            ? Closure::fromCallable($beforeChild)
+            : null;
+
         return $this;
     }
 
@@ -78,7 +85,11 @@ class Agent extends Workflow implements AgentInterface
 
         // Select the appropriate ToolNode based on the parallel execution setting
         $toolNode = $this->parallelToolCalls
-            ? new ParallelToolNode($this->toolMaxRuns, $this->resolveToolErrorHandler())
+            ? new ParallelToolNode(
+                $this->toolMaxRuns,
+                $this->resolveToolErrorHandler(),
+                $this->beforeParallelToolChild,
+            )
             : new ToolNode($this->toolMaxRuns, $this->resolveToolErrorHandler());
 
         // Add nodes to the workflow instance

--- a/src/Agent/Nodes/ParallelToolNode.php
+++ b/src/Agent/Nodes/ParallelToolNode.php
@@ -32,6 +32,20 @@ use function array_values;
 
 class ParallelToolNode extends ToolNode
 {
+    protected ?Closure $beforeChild;
+
+    public function __construct(
+        int $maxRuns = 10,
+        ?callable $errorHandler = null,
+        ?callable $beforeChild = null,
+    ) {
+        parent::__construct($maxRuns, $errorHandler);
+
+        $this->beforeChild = $beforeChild !== null
+            ? Closure::fromCallable($beforeChild)
+            : null;
+    }
+
     /**
      * @throws ToolException
      * @throws ToolRunsExceededException
@@ -75,7 +89,13 @@ class ParallelToolNode extends ToolNode
         }
 
         // Execute tools concurrently and collect serialized tool states
-        $serializedTools = Fork::new()->run(
+        $fork = Fork::new();
+
+        if ($this->beforeChild !== null) {
+            $fork->before(child: $this->beforeChild);
+        }
+
+        $serializedTools = $fork->run(
             ...array_map(
                 fn (ToolInterface $tool): Closure => function () use ($tool): string {
                     try {

--- a/tests/Tools/ParallelToolsTest.php
+++ b/tests/Tools/ParallelToolsTest.php
@@ -23,7 +23,16 @@ use ReflectionClass;
 use function extension_loaded;
 use function usleep;
 use function class_exists;
+use function file_get_contents;
+use function file_put_contents;
 use function implode;
+use function is_file;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+use const FILE_APPEND;
+use const LOCK_EX;
 
 /**
  * Simple test tool that can be serialized for parallel execution.
@@ -186,6 +195,44 @@ class ParallelToolsTest extends TestCase
 
         // Provider should have been called twice (tool calls + final response)
         $provider->assertCallCount(2);
+    }
+
+    public function test_before_child_callback_runs_for_each_parallel_tool(): void
+    {
+        $marker = tempnam(sys_get_temp_dir(), 'neuron-parallel-child-');
+        $this->assertNotFalse($marker);
+
+        $toolA = (new TestToolA('tool_a', 'Tool A'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input for tool A', true));
+        $toolB = (new TestToolB('tool_b', 'Tool B'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input for tool B', true));
+
+        $provider = new FakeAIProvider(
+            new ToolCallMessage(null, [
+                (clone $toolA)->setCallId('call_1')->setInputs(['input' => 'test A']),
+                (clone $toolB)->setCallId('call_2')->setInputs(['input' => 'test B']),
+            ]),
+            new AssistantMessage('Done'),
+        );
+
+        $agent = Agent::make();
+        $agent->setAiProvider($provider);
+        $agent->parallelToolCalls(
+            true,
+            beforeChild: static fn () => file_put_contents($marker, '1', FILE_APPEND | LOCK_EX),
+        );
+        $agent->addTool($toolA);
+        $agent->addTool($toolB);
+
+        try {
+            $agent->chat(new UserMessage('Run tools in parallel'))->run();
+
+            $this->assertSame('11', file_get_contents($marker));
+        } finally {
+            if (is_file($marker)) {
+                unlink($marker);
+            }
+        }
     }
 
     public function test_parallel_execution_returns_correct_results(): void


### PR DESCRIPTION
# Pull Request Template

## Type of Change
**Select ONE type only. Multi-purpose PRs will be rejected.**

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔧 Improvement/Enhancement (non-breaking change which improves existing functionality)
- [ ] 📖 Documentation update
- [ ] 🧹 Code cleanup/refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

### What does this PR do?

Adds an optional `beforeChild` callback to parallel tool execution. The callback is passed to `Spatie\Fork\Fork::before()` and runs in every child process before its tool executes.

### Why is this change needed?

`pcntl_fork()` inherits open process resources, including database and cache connections. When parallel tools reuse an inherited PDO/MySQL socket, concurrent requests can corrupt the client/server protocol and cause errors such as `Wrong COM_STMT_PREPARE response size`.

Neuron currently creates `Fork::new()->run(...)` internally without exposing a child initialization hook, so applications cannot safely reconnect inherited resources while retaining parallel execution.

### How does this change should be used and documented?

The callback is optional and fully backward compatible:

```php
$agent->parallelToolCalls(
    true,
    beforeChild: static fn () => DB::reconnect(),
);
```

The callback is framework-agnostic. Applications can use it to reconnect PDO, Redis, or any other process-bound resource.

## Related Issues

- No existing issue found.

## Testing

- [x] I have tested this change locally
- [x] I have added/updated unit tests where appropriate
- [ ] All existing tests pass
- [ ] I have tested this with different PHP versions (if applicable)

Tested in the project's PHP 8.3 Linux Docker image with real `pcntl` forks:

- `tests/Tools/ParallelToolsTest.php`
- `tests/Agent/Nodes/ParallelToolNodeTest.php`
- 10 tests passed, 32 assertions
- PHPStan passed for all changed files
- PHP CS Fixer passed for all changed files

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces breaking changes (explain below)

## Documentation

- [ ] No documentation changes needed
- [ ] I have updated relevant documentation
- [ ] Documentation will be updated in a separate PR
- [x] New documentation needs to be created

## Checklist

- [x] My code follows the project's coding standards (PHPStan)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] My commit messages are clear and descriptive
- [x] This PR addresses only ONE specific goal/issue

## Additional Notes

This patch was prepared and the pull request was authored with OpenAI Codex (GPT-5), based on a production failure reproduced from parallel Laravel tools using an inherited PDO connection.