### PR TITLE
Allow initializing resources in parallel tool children safely

### DIFF
--- a/src/Agent/Agent.php
+++ b/src/Agent/Agent.php
@@ -21,6 +21,7 @@ use NeuronAI\Workflow\Persistence\PersistenceInterface;
 use NeuronAI\Workflow\Workflow;
 use NeuronAI\Workflow\WorkflowHandlerInterface;
 use NeuronAI\Workflow\WorkflowState;
+use Closure;
 use Throwable;
 
 use function is_array;
@@ -41,6 +42,8 @@ class Agent extends Workflow implements AgentInterface
 
     protected bool $parallelToolCalls = false;
 
+    protected ?Closure $beforeParallelToolChild = null;
+
     public function init(?InterruptRequest $resumeRequest = null): WorkflowHandlerInterface
     {
         $this->resolveState()->resetToolRuns();
@@ -50,14 +53,18 @@ class Agent extends Workflow implements AgentInterface
     }
 
     /**
-     * Determines whether tools should be executed in parallel.
-     * Override this method to return true to enable parallel tool execution.
+     * Determines whether tools should be executed in parallel and optionally
+     * configures a callback to initialize resources in each child process.
      *
      * Note: Parallel execution requires the pcntl extension and spatie/fork package.
      */
-    public function parallelToolCalls(bool $enabled): AgentInterface
+    public function parallelToolCalls(bool $enabled, ?callable $beforeChild = null): AgentInterface
     {
         $this->parallelToolCalls = $enabled;
+        $this->beforeParallelToolChild = $beforeChild !== null
+            ? Closure::fromCallable($beforeChild)
+            : null;
+
         return $this;
     }
 
@@ -78,7 +85,11 @@ class Agent extends Workflow implements AgentInterface
 
         // Select the appropriate ToolNode based on the parallel execution setting
         $toolNode = $this->parallelToolCalls
-            ? new ParallelToolNode($this->toolMaxRuns, $this->resolveToolErrorHandler())
+            ? new ParallelToolNode(
+                $this->toolMaxRuns,
+                $this->resolveToolErrorHandler(),
+                $this->beforeParallelToolChild,
+            )
             : new ToolNode($this->toolMaxRuns, $this->resolveToolErrorHandler());
 
         // Add nodes to the workflow instance

--- a/src/Agent/Agent.php
+++ b/src/Agent/Agent.php
@@ -44,6 +44,8 @@ class Agent extends Workflow implements AgentInterface
 
     protected ?Closure $beforeParallelToolChild = null;
 
+    protected ?Closure $afterParallelToolChild = null;
+
     public function init(?InterruptRequest $resumeRequest = null): WorkflowHandlerInterface
     {
         $this->resolveState()->resetToolRuns();
@@ -54,15 +56,21 @@ class Agent extends Workflow implements AgentInterface
 
     /**
      * Determines whether tools should be executed in parallel and optionally
-     * configures a callback to initialize resources in each child process.
+     * configures callbacks to initialize and clean up resources in each child process.
      *
      * Note: Parallel execution requires the pcntl extension and spatie/fork package.
      */
-    public function parallelToolCalls(bool $enabled, ?callable $beforeChild = null): AgentInterface
-    {
+    public function parallelToolCalls(
+        bool $enabled,
+        ?callable $beforeChild = null,
+        ?callable $afterChild = null,
+    ): AgentInterface {
         $this->parallelToolCalls = $enabled;
         $this->beforeParallelToolChild = $beforeChild !== null
             ? Closure::fromCallable($beforeChild)
+            : null;
+        $this->afterParallelToolChild = $afterChild !== null
+            ? Closure::fromCallable($afterChild)
             : null;
 
         return $this;
@@ -89,6 +97,7 @@ class Agent extends Workflow implements AgentInterface
                 $this->toolMaxRuns,
                 $this->resolveToolErrorHandler(),
                 $this->beforeParallelToolChild,
+                $this->afterParallelToolChild,
             )
             : new ToolNode($this->toolMaxRuns, $this->resolveToolErrorHandler());
 

--- a/src/Agent/Nodes/ParallelToolNode.php
+++ b/src/Agent/Nodes/ParallelToolNode.php
@@ -32,6 +32,20 @@ use function array_values;
 
 class ParallelToolNode extends ToolNode
 {
+    protected ?Closure $beforeChild;
+
+    public function __construct(
+        int $maxRuns = 10,
+        ?callable $errorHandler = null,
+        ?callable $beforeChild = null,
+    ) {
+        parent::__construct($maxRuns, $errorHandler);
+
+        $this->beforeChild = $beforeChild !== null
+            ? Closure::fromCallable($beforeChild)
+            : null;
+    }
+
     /**
      * @throws ToolException
      * @throws ToolRunsExceededException
@@ -75,7 +89,13 @@ class ParallelToolNode extends ToolNode
         }
 
         // Execute tools concurrently and collect serialized tool states
-        $serializedTools = Fork::new()->run(
+        $fork = Fork::new();
+
+        if ($this->beforeChild !== null) {
+            $fork->before(child: $this->beforeChild);
+        }
+
+        $serializedTools = $fork->run(
             ...array_map(
                 fn (ToolInterface $tool): Closure => function () use ($tool): string {
                     try {

--- a/src/Agent/Nodes/ParallelToolNode.php
+++ b/src/Agent/Nodes/ParallelToolNode.php
@@ -34,15 +34,21 @@ class ParallelToolNode extends ToolNode
 {
     protected ?Closure $beforeChild;
 
+    protected ?Closure $afterChild;
+
     public function __construct(
         int $maxRuns = 10,
         ?callable $errorHandler = null,
         ?callable $beforeChild = null,
+        ?callable $afterChild = null,
     ) {
         parent::__construct($maxRuns, $errorHandler);
 
         $this->beforeChild = $beforeChild !== null
             ? Closure::fromCallable($beforeChild)
+            : null;
+        $this->afterChild = $afterChild !== null
+            ? Closure::fromCallable($afterChild)
             : null;
     }
 
@@ -90,16 +96,23 @@ class ParallelToolNode extends ToolNode
 
         // Execute tools concurrently and collect serialized tool states
         $beforeChild = $this->beforeChild;
+        $afterChild = $this->afterChild;
         $serializedTools = Fork::new()->run(
             ...array_map(
-                fn (ToolInterface $tool): Closure => function () use ($tool, $beforeChild): string {
+                fn (ToolInterface $tool): Closure => function () use ($tool, $beforeChild, $afterChild): string {
                     try {
                         if ($beforeChild !== null) {
                             $beforeChild();
                         }
 
-                        // Execute the tool - this mutates the tool's internal state
-                        $tool->execute();
+                        try {
+                            // Execute the tool - this mutates the tool's internal state
+                            $tool->execute();
+                        } finally {
+                            if ($afterChild !== null) {
+                                $afterChild();
+                            }
+                        }
 
                         // Serialize the entire tool object with its new state
                         return serialize($tool);

--- a/src/Agent/Nodes/ParallelToolNode.php
+++ b/src/Agent/Nodes/ParallelToolNode.php
@@ -89,16 +89,15 @@ class ParallelToolNode extends ToolNode
         }
 
         // Execute tools concurrently and collect serialized tool states
-        $fork = Fork::new();
-
-        if ($this->beforeChild !== null) {
-            $fork->before(child: $this->beforeChild);
-        }
-
-        $serializedTools = $fork->run(
+        $beforeChild = $this->beforeChild;
+        $serializedTools = Fork::new()->run(
             ...array_map(
-                fn (ToolInterface $tool): Closure => function () use ($tool): string {
+                fn (ToolInterface $tool): Closure => function () use ($tool, $beforeChild): string {
                     try {
+                        if ($beforeChild !== null) {
+                            $beforeChild();
+                        }
+
                         // Execute the tool - this mutates the tool's internal state
                         $tool->execute();
 

--- a/tests/Tools/ParallelToolsTest.php
+++ b/tests/Tools/ParallelToolsTest.php
@@ -235,6 +235,37 @@ class ParallelToolsTest extends TestCase
         }
     }
 
+    public function test_before_child_callback_exception_is_propagated(): void
+    {
+        $toolA = (new TestToolA('tool_a', 'Tool A'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input for tool A', true));
+        $toolB = (new TestToolB('tool_b', 'Tool B'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input for tool B', true));
+
+        $provider = new FakeAIProvider(
+            new ToolCallMessage(null, [
+                (clone $toolA)->setCallId('call_1')->setInputs(['input' => 'test A']),
+                (clone $toolB)->setCallId('call_2')->setInputs(['input' => 'test B']),
+            ]),
+        );
+
+        $agent = Agent::make();
+        $agent->setAiProvider($provider);
+        $agent->parallelToolCalls(
+            true,
+            beforeChild: static function (): void {
+                throw new RuntimeException('Parallel child initialization failed');
+            },
+        );
+        $agent->addTool($toolA);
+        $agent->addTool($toolB);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Parallel child initialization failed');
+
+        $agent->chat(new UserMessage('Run tools in parallel'))->run();
+    }
+
     public function test_parallel_execution_returns_correct_results(): void
     {
         $multiplyTool = new MultiplyTool('multiply', 'Multiply two numbers');

--- a/tests/Tools/ParallelToolsTest.php
+++ b/tests/Tools/ParallelToolsTest.php
@@ -266,6 +266,114 @@ class ParallelToolsTest extends TestCase
         $agent->chat(new UserMessage('Run tools in parallel'))->run();
     }
 
+    public function test_after_child_callback_runs_for_each_parallel_tool(): void
+    {
+        $marker = tempnam(sys_get_temp_dir(), 'neuron-parallel-child-');
+        $this->assertNotFalse($marker);
+
+        $toolA = (new TestToolA('tool_a', 'Tool A'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input for tool A', true));
+        $toolB = (new TestToolB('tool_b', 'Tool B'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input for tool B', true));
+
+        $provider = new FakeAIProvider(
+            new ToolCallMessage(null, [
+                (clone $toolA)->setCallId('call_1')->setInputs(['input' => 'test A']),
+                (clone $toolB)->setCallId('call_2')->setInputs(['input' => 'test B']),
+            ]),
+            new AssistantMessage('Done'),
+        );
+
+        $agent = Agent::make();
+        $agent->setAiProvider($provider);
+        $agent->parallelToolCalls(
+            true,
+            afterChild: static fn () => file_put_contents($marker, '1', FILE_APPEND | LOCK_EX),
+        );
+        $agent->addTool($toolA);
+        $agent->addTool($toolB);
+
+        try {
+            $agent->chat(new UserMessage('Run tools in parallel'))->run();
+
+            $this->assertSame('11', file_get_contents($marker));
+        } finally {
+            if (is_file($marker)) {
+                unlink($marker);
+            }
+        }
+    }
+
+    public function test_after_child_callback_runs_when_tool_execution_fails(): void
+    {
+        $marker = tempnam(sys_get_temp_dir(), 'neuron-parallel-child-');
+        $this->assertNotFalse($marker);
+
+        $failingTool = (new FailingTool('failing_tool', 'This tool will fail'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input', true));
+        $workingTool = (new WorkingTool('working_tool', 'This tool works'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input', true));
+
+        $provider = new FakeAIProvider(
+            new ToolCallMessage(null, [
+                (clone $failingTool)->setCallId('call_1')->setInputs(['input' => 'test']),
+                (clone $workingTool)->setCallId('call_2')->setInputs(['input' => 'test']),
+            ]),
+        );
+
+        $agent = Agent::make();
+        $agent->setAiProvider($provider);
+        $agent->parallelToolCalls(
+            true,
+            afterChild: static fn () => file_put_contents($marker, '1', FILE_APPEND | LOCK_EX),
+        );
+        $agent->addTool($failingTool);
+        $agent->addTool($workingTool);
+
+        try {
+            $agent->chat(new UserMessage('Run tools in parallel'))->run();
+            $this->fail('The failing tool did not throw an exception.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Tool execution failed', $exception->getMessage());
+            $this->assertSame('11', file_get_contents($marker));
+        } finally {
+            if (is_file($marker)) {
+                unlink($marker);
+            }
+        }
+    }
+
+    public function test_after_child_callback_exception_is_propagated(): void
+    {
+        $toolA = (new TestToolA('tool_a', 'Tool A'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input for tool A', true));
+        $toolB = (new TestToolB('tool_b', 'Tool B'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input for tool B', true));
+
+        $provider = new FakeAIProvider(
+            new ToolCallMessage(null, [
+                (clone $toolA)->setCallId('call_1')->setInputs(['input' => 'test A']),
+                (clone $toolB)->setCallId('call_2')->setInputs(['input' => 'test B']),
+            ]),
+        );
+
+        $agent = Agent::make();
+        $agent->setAiProvider($provider);
+        $agent->parallelToolCalls(
+            true,
+            afterChild: static function (): void {
+                throw new RuntimeException('Parallel child cleanup failed');
+            },
+        );
+        $agent->addTool($toolA);
+        $agent->addTool($toolB);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Parallel child cleanup failed');
+
+        $agent->chat(new UserMessage('Run tools in parallel'))->run();
+    }
+
     public function test_parallel_execution_returns_correct_results(): void
     {
         $multiplyTool = new MultiplyTool('multiply', 'Multiply two numbers');

--- a/tests/Tools/ParallelToolsTest.php
+++ b/tests/Tools/ParallelToolsTest.php
@@ -23,7 +23,16 @@ use ReflectionClass;
 use function extension_loaded;
 use function usleep;
 use function class_exists;
+use function file_get_contents;
+use function file_put_contents;
 use function implode;
+use function is_file;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+use const FILE_APPEND;
+use const LOCK_EX;
 
 /**
  * Simple test tool that can be serialized for parallel execution.
@@ -186,6 +195,44 @@ class ParallelToolsTest extends TestCase
 
         // Provider should have been called twice (tool calls + final response)
         $provider->assertCallCount(2);
+    }
+
+    public function test_before_child_callback_runs_for_each_parallel_tool(): void
+    {
+        $marker = tempnam(sys_get_temp_dir(), 'neuron-parallel-child-');
+        $this->assertNotFalse($marker);
+
+        $toolA = (new TestToolA('tool_a', 'Tool A'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input for tool A', true));
+        $toolB = (new TestToolB('tool_b', 'Tool B'))
+            ->addProperty(new ToolProperty('input', PropertyType::STRING, 'Input for tool B', true));
+
+        $provider = new FakeAIProvider(
+            new ToolCallMessage(null, [
+                (clone $toolA)->setCallId('call_1')->setInputs(['input' => 'test A']),
+                (clone $toolB)->setCallId('call_2')->setInputs(['input' => 'test B']),
+            ]),
+            new AssistantMessage('Done'),
+        );
+
+        $agent = Agent::make();
+        $agent->setAiProvider($provider);
+        $agent->parallelToolCalls(
+            true,
+            beforeChild: static fn () => file_put_contents($marker, '1', FILE_APPEND | LOCK_EX),
+        );
+        $agent->addTool($toolA);
+        $agent->addTool($toolB);
+
+        try {
+            $agent->chat(new UserMessage('Run tools in parallel'))->run();
+
+            $this->assertSame('11', file_get_contents($marker));
+        } finally {
+            if (is_file($marker)) {
+                unlink($marker);
+            }
+        }
     }
 
     public function test_parallel_execution_returns_correct_results(): void


### PR DESCRIPTION
## Type of Change

- [x] 🔧 Improvement/Enhancement

## Description

### What does this PR do?

This PR adds an optional `beforeChild` callback to `Agent::parallelToolCalls()`. The callback is passed to `ParallelToolNode` and executed once inside every forked tool task, immediately before the tool itself runs.

Child-initialization failures are caught by the existing task-level error handling and propagated through the normal tool error path instead of becoming an invalid tool result. Existing integrations remain unchanged when the callback is omitted.

### Why is this change needed?

Forked child processes may inherit process-bound resources that cannot safely be shared, such as database connections. In a Laravel integration this caused multiple processes to use the same inherited MySQL socket, resulting in protocol errors such as:

```text
Wrong COM_STMT_PREPARE response size. Received 1
```

Framework integrations need a generic hook to reset or initialize these resources independently in every child process.

Executing the initializer through `Spatie\Fork\Fork::before()` is unsafe for this use case because that hook runs outside the protected task callback. If initialization throws, the child may return an empty payload. `unserialize()` then produces `false`, causing a misleading `ToolResultChunk` type error and hiding the original exception.

Running the initializer inside the task `try` block preserves the original error and routes it through Neuron's existing tool error handling.

### Usage

The callback is optional and backward compatible:

```php
$agent->parallelToolCalls(
    true,
    beforeChild: static function (): void {
        // Reset or initialize process-bound resources for this child.
    },
);
```

For example, a Laravel integration can purge the inherited database connection so that the child reconnects lazily when required:

```php
$agent->parallelToolCalls(
    true,
    beforeChild: static function (): void {
        DB::purge();
    },
);
```

The callback is invoked only when multiple tools are actually executed in parallel.

## Related Issues

None.

## Testing

- [x] Tested locally on Linux with PHP 8.3 and `pcntl` enabled.
- [x] Added tests for successful per-child initialization.
- [x] Added a regression test for initializer exception propagation.
- [x] Full test suite passes: 1225 tests, 5100 assertions, 71 skipped.
- [x] Parallel tools suite passes: 8 tests, 27 assertions.
- [x] PHPStan passes with no errors.
- [x] PHP CS Fixer dry run is clean.
- [x] Verified in a Laravel integration with two parallel tools and child-local database connection cleanup.
- [x] Manually validated by a human on a production system with multiple agents, different tool sets, and real chat workflows.

## Breaking Changes

None. The new argument is optional and existing calls remain compatible.

## Documentation

No documentation changes are required. The new optional argument is covered by PHPDoc, usage examples in this PR, and automated tests.

## Checklist

- [x] Code follows the project's coding standards.
- [x] Changes were self-reviewed.
- [x] No new warnings or errors are introduced.
- [x] Commit messages are clear and descriptive.
- [x] The PR addresses one specific goal.

## Additional Notes

The implementation, debugging, Linux `pcntl` reproduction, and test runs were performed with assistance from OpenAI Codex using GPT-5.6 Sol.