### PR TITLE
Send neuron-ai/4.x as User-Agent from every HTTP client

### DIFF
--- a/src/HttpClient/AGENTS.md
+++ b/src/HttpClient/AGENTS.md
@@ -36,6 +36,9 @@ surface incrementally — live streaming is guaranteed, not client-dependent. It
 constructor argument is the raw `CURLOPT_*` escape hatch (proxies, custom CA bundles, ...) and
 wins over the built-in defaults.
 
+All three send `User-Agent: neuron-ai/4.x` (`HttpClientInterface::USER_AGENT`) unless
+`withHeaders()` or the request supplies its own.
+
 ### Request/response hooks
 
 `CurlHttpClient` offers taps — deliberately not middleware:
@@ -93,11 +96,12 @@ class MyProvider {
 
 ## Testing
 
-`tests/HttpClient/CurlHttpClientTest.php` boots PHP's built-in server
-(`tests/HttpClient/fixtures/server.php`) and exercises the real curl stack, including the
-assertion that SSE chunks arrive incrementally. Provider tests fake HTTP in-process through
-`GuzzleHttpClient` + Guzzle's `MockHandler` — they test provider logic through the seam, which
-is implementation-agnostic, and keep the Guzzle adapter exercised.
+`tests/HttpClient/CurlHttpClientTest.php` and `AmpHttpClientTest.php` boot PHP's built-in server
+(`BootsFixtureServer` trait on `tests/HttpClient/fixtures/server.php`) and exercise the real
+stack; the curl test includes the assertion that SSE chunks arrive incrementally. Provider
+tests fake HTTP in-process through `GuzzleHttpClient` + Guzzle's `MockHandler` — they test
+provider logic through the seam, which is implementation-agnostic, and keep the Guzzle adapter
+exercised.
 
 ## Dependencies
 

--- a/src/HttpClient/Amp/AmpHttpClient.php
+++ b/src/HttpClient/Amp/AmpHttpClient.php
@@ -8,6 +8,7 @@ use Amp\ByteStream\ReadableResourceStream;
 use Amp\Http\Client\Form;
 use Amp\Http\Client\HttpClient;
 use Amp\Http\Client\HttpClientBuilder;
+use Amp\Http\Client\Interceptor\SetRequestHeaderIfUnset;
 use Amp\Http\Client\Request;
 use Amp\Http\Client\Response;
 use Amp\Http\Client\StreamedContent;
@@ -151,7 +152,9 @@ class AmpHttpClient implements HttpClientInterface
 
     protected function getClient(): HttpClient
     {
-        return $this->client ??= HttpClientBuilder::buildDefault();
+        return $this->client ??= (new HttpClientBuilder())
+            ->intercept(new SetRequestHeaderIfUnset('User-Agent', HttpClientInterface::USER_AGENT))
+            ->build();
     }
 
     /**

--- a/src/HttpClient/Curl/CurlHttpClient.php
+++ b/src/HttpClient/Curl/CurlHttpClient.php
@@ -46,6 +46,7 @@ use const CURLOPT_RETURNTRANSFER;
 use const CURLOPT_SHARE;
 use const CURLOPT_TIMEOUT_MS;
 use const CURLOPT_URL;
+use const CURLOPT_USERAGENT;
 use const CURLOPT_WRITEFUNCTION;
 use const CURLSHOPT_SHARE;
 
@@ -268,6 +269,8 @@ class CurlHttpClient implements HttpClientInterface
         $options = [
             CURLOPT_URL => $this->resolveUri($request),
             CURLOPT_CUSTOMREQUEST => $request->method->value,
+            // A User-Agent line in CURLOPT_HTTPHEADER replaces this default.
+            CURLOPT_USERAGENT => HttpClientInterface::USER_AGENT,
             CURLOPT_CONNECTTIMEOUT_MS => (int) ($this->connectTimeout * 1000),
             CURLOPT_TIMEOUT_MS => (int) ($this->timeout * 1000),
             CURLOPT_FOLLOWLOCATION => true,

--- a/src/HttpClient/Guzzle/GuzzleHttpClient.php
+++ b/src/HttpClient/Guzzle/GuzzleHttpClient.php
@@ -108,7 +108,10 @@ class GuzzleHttpClient implements HttpClientInterface
             return $this->client;
         }
 
-        $config = [];
+        // Guzzle adds client-level headers only when the request lacks them.
+        $config = [
+            RequestOptions::HEADERS => ['User-Agent' => HttpClientInterface::USER_AGENT],
+        ];
 
         if ($this->handler instanceof HandlerStack) {
             $config['handler'] = $this->handler;

--- a/src/HttpClient/HttpClientInterface.php
+++ b/src/HttpClient/HttpClientInterface.php
@@ -18,6 +18,12 @@ use NeuronAI\Exceptions\HttpException;
 interface HttpClientInterface
 {
     /**
+     * Sent as User-Agent by every built-in client unless withHeaders()
+     * or the request supplies its own.
+     */
+    public const USER_AGENT = 'neuron-ai/4.x';
+
+    /**
      * Send an HTTP request and return the response.
      *
      * This method should block until the response is received.

--- a/src/MCP/StreamableHttpTransport.php
+++ b/src/MCP/StreamableHttpTransport.php
@@ -41,7 +41,6 @@ class StreamableHttpTransport implements McpTransportInterface
             ->withHeaders([
                 'Accept' => 'application/json, text/event-stream',
                 'Content-Type' => 'application/json',
-                'User-Agent' => 'neuron-ai/1.0.0',
             ])
             ->withTimeout((float) ($config['timeout'] ?? 30));
     }

--- a/tests/HttpClient/AmpHttpClientTest.php
+++ b/tests/HttpClient/AmpHttpClientTest.php
@@ -19,6 +19,8 @@ use function unlink;
 
 class AmpHttpClientTest extends TestCase
 {
+    use BootsFixtureServer;
+
     public function test_is_multipart_data_detection(): void
     {
         $tmpFile = tempnam(sys_get_temp_dir(), 'test');
@@ -109,5 +111,21 @@ class AmpHttpClientTest extends TestCase
 
         fclose($fileResource);
         unlink($tmpFile);
+    }
+
+    public function test_sends_neuron_user_agent_by_default(): void
+    {
+        $response = (new AmpHttpClient())->request(HttpRequest::get(static::$baseUri . '/echo'));
+
+        $this->assertEquals('neuron-ai/4.x', $response->json()['userAgent']);
+    }
+
+    public function test_custom_user_agent_replaces_the_default(): void
+    {
+        $client = (new AmpHttpClient())->withHeaders(['User-Agent' => 'my-app/1.0']);
+
+        $response = $client->request(HttpRequest::get(static::$baseUri . '/echo'));
+
+        $this->assertEquals('my-app/1.0', $response->json()['userAgent']);
     }
 }

--- a/tests/HttpClient/BootsFixtureServer.php
+++ b/tests/HttpClient/BootsFixtureServer.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\HttpClient;
+
+use function fclose;
+use function fsockopen;
+use function is_resource;
+use function proc_open;
+use function proc_terminate;
+use function random_int;
+use function usleep;
+
+/**
+ * Boots PHP's built-in server on fixtures/server.php so a test class can
+ * exercise a real HTTP stack.
+ */
+trait BootsFixtureServer
+{
+    protected static string $baseUri;
+
+    /**
+     * @var resource
+     */
+    protected static $serverProcess;
+
+    public static function setUpBeforeClass(): void
+    {
+        $port = random_int(49152, 65000);
+        static::$baseUri = "http://127.0.0.1:{$port}";
+
+        $process = proc_open(
+            ['php', '-S', "127.0.0.1:{$port}", __DIR__ . '/fixtures/server.php'],
+            [2 => ['pipe', 'w']],
+            $pipes,
+            null,
+            ['PHP_CLI_SERVER_WORKERS' => '2'],
+        );
+
+        if (!is_resource($process)) {
+            self::fail('Failed to start the built-in PHP server fixture');
+        }
+
+        static::$serverProcess = $process;
+        static::waitForServer($port);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        proc_terminate(static::$serverProcess);
+    }
+
+    protected static function waitForServer(int $port): void
+    {
+        for ($attempt = 0; $attempt < 100; $attempt++) {
+            $socket = @fsockopen('127.0.0.1', $port, $errorCode, $errorMessage, 0.1);
+
+            if ($socket !== false) {
+                fclose($socket);
+                return;
+            }
+
+            usleep(50_000);
+        }
+
+        self::fail('The built-in PHP server fixture never became reachable');
+    }
+}

--- a/tests/HttpClient/CurlHttpClientTest.php
+++ b/tests/HttpClient/CurlHttpClientTest.php
@@ -12,22 +12,15 @@ use NeuronAI\HttpClient\HttpResponse;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
-use function fclose;
 use function file_put_contents;
 use function fopen;
-use function fsockopen;
-use function is_resource;
 use function json_decode;
 use function microtime;
-use function proc_open;
-use function proc_terminate;
-use function random_int;
 use function rtrim;
 use function str_repeat;
 use function sys_get_temp_dir;
 use function trim;
 use function unlink;
-use function usleep;
 
 /**
  * Exercises the real curl stack against PHP's built-in server, including
@@ -36,54 +29,7 @@ use function usleep;
  */
 class CurlHttpClientTest extends TestCase
 {
-    protected static string $baseUri;
-
-    /**
-     * @var resource
-     */
-    protected static $serverProcess;
-
-    public static function setUpBeforeClass(): void
-    {
-        $port = random_int(49152, 65000);
-        static::$baseUri = "http://127.0.0.1:{$port}";
-
-        $process = proc_open(
-            ['php', '-S', "127.0.0.1:{$port}", __DIR__ . '/fixtures/server.php'],
-            [2 => ['pipe', 'w']],
-            $pipes,
-            null,
-            ['PHP_CLI_SERVER_WORKERS' => '2'],
-        );
-
-        if (!is_resource($process)) {
-            self::fail('Failed to start the built-in PHP server fixture');
-        }
-
-        static::$serverProcess = $process;
-        static::waitForServer($port);
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        proc_terminate(static::$serverProcess);
-    }
-
-    protected static function waitForServer(int $port): void
-    {
-        for ($attempt = 0; $attempt < 100; $attempt++) {
-            $socket = @fsockopen('127.0.0.1', $port, $errorCode, $errorMessage, 0.1);
-
-            if ($socket !== false) {
-                fclose($socket);
-                return;
-            }
-
-            usleep(50_000);
-        }
-
-        self::fail('The built-in PHP server fixture never became reachable');
-    }
+    use BootsFixtureServer;
 
     public function test_get_request(): void
     {
@@ -118,6 +64,22 @@ class CurlHttpClientTest extends TestCase
         );
 
         $this->assertEquals('', $response->json()['expect']);
+    }
+
+    public function test_sends_neuron_user_agent_by_default(): void
+    {
+        $response = (new CurlHttpClient())->request(HttpRequest::get(static::$baseUri . '/echo'));
+
+        $this->assertEquals('neuron-ai/4.x', $response->json()['userAgent']);
+    }
+
+    public function test_custom_user_agent_replaces_the_default(): void
+    {
+        $client = new CurlHttpClient(customHeaders: ['User-Agent' => 'my-app/1.0']);
+
+        $response = $client->request(HttpRequest::get(static::$baseUri . '/echo'));
+
+        $this->assertEquals('my-app/1.0', $response->json()['userAgent']);
     }
 
     public function test_multipart_body_with_resource(): void

--- a/tests/HttpClient/GuzzleHttpClientTest.php
+++ b/tests/HttpClient/GuzzleHttpClientTest.php
@@ -243,4 +243,25 @@ class GuzzleHttpClientTest extends TestCase
         $this->assertStringContainsString('Request timed out', $exception->getMessage());
         $this->assertNull($exception->response);
     }
+
+    public function test_sends_neuron_user_agent_by_default(): void
+    {
+        $mock = new MockHandler([new Response(200)]);
+        $client = new GuzzleHttpClient(handler: HandlerStack::create($mock));
+
+        $client->request(HttpRequest::get('https://example.com/api'));
+
+        $this->assertEquals('neuron-ai/4.x', $mock->getLastRequest()->getHeaderLine('User-Agent'));
+    }
+
+    public function test_custom_user_agent_replaces_the_default(): void
+    {
+        $mock = new MockHandler([new Response(200)]);
+        $client = (new GuzzleHttpClient(handler: HandlerStack::create($mock)))
+            ->withHeaders(['User-Agent' => 'my-app/1.0']);
+
+        $client->request(HttpRequest::get('https://example.com/api'));
+
+        $this->assertEquals('my-app/1.0', $mock->getLastRequest()->getHeaderLine('User-Agent'));
+    }
 }

--- a/tests/HttpClient/fixtures/server.php
+++ b/tests/HttpClient/fixtures/server.php
@@ -24,6 +24,7 @@ switch ($path) {
             'authorization' => $_SERVER['HTTP_AUTHORIZATION'] ?? '',
             'expect' => $_SERVER['HTTP_EXPECT'] ?? '',
             'xHook' => $_SERVER['HTTP_X_HOOK'] ?? '',
+            'userAgent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
             'body' => \file_get_contents('php://input'),
         ]);
         break;

--- a/tests/MCP/McpConnectorTest.php
+++ b/tests/MCP/McpConnectorTest.php
@@ -74,7 +74,6 @@ class McpConnectorTest extends TestCase
             ->with([
                 'Accept' => 'application/json, text/event-stream',
                 'Content-Type' => 'application/json',
-                'User-Agent' => 'neuron-ai/1.0.0',
             ])
             ->willReturnSelf();
         $httpClient->expects($this->once())


### PR DESCRIPTION
# Pull Request Template

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🔧 Improvement/Enhancement (non-breaking change which improves existing functionality)
- [ ] 📖 Documentation update
- [ ] 🧹 Code cleanup/refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

### What does this PR do?

Every built-in HTTP client now sends `User-Agent: neuron-ai/4.x` unless `withHeaders()` or the request supplies its own. The token lives once, as `HttpClientInterface::USER_AGENT`, and each adapter applies it the way its library treats as a set-if-unset default:

- `CurlHttpClient` through `CURLOPT_USERAGENT`, which libcurl drops as soon as a `User-Agent` line appears in `CURLOPT_HTTPHEADER`.
- `GuzzleHttpClient` through a client-level header, which Guzzle only adds when the request lacks one.
- `AmpHttpClient` through Amp's own `SetRequestHeaderIfUnset` interceptor on the built client.

`StreamableHttpTransport` drops its stale hardcoded `neuron-ai/1.0.0` header and relies on the client default like every other component. Every outbound request in `src/` already flows through these three adapters, so providers, vector stores, toolkits, and MCP are all covered.

### Why is this change needed?

Until now the identity sent to external endpoints depended on the adapter: raw ext-curl, the default client, sent no `User-Agent` at all, Guzzle sent `GuzzleHttp/7`, and Amp sent `amphp/http-client/5.x`. Only the MCP transport identified the framework, with a version string that had gone stale. A single major-only token, in the same style as Guzzle's and Amp's own, identifies Neuron consistently and only needs updating once per major.

### How does this change should be used and documented?

Nothing to do for applications: the header is sent automatically. An application that wants its own identity keeps passing `User-Agent` through `withHeaders()` or per-request headers, which override the default on all three adapters. The default is documented in `src/HttpClient/AGENTS.md`.

## Related Issues

- None

## Testing

- [x] I have tested this change locally
- [x] I have added/updated unit tests where appropriate
- [x] All existing tests pass
- [ ] I have tested this with different PHP versions (if applicable)

The fixture server now echoes the request's `User-Agent`, and the server boot moved from `CurlHttpClientTest` into a `BootsFixtureServer` trait so `AmpHttpClientTest` exercises the real stack too. Each adapter has a default test and an override test: curl and Amp against the built-in server, Guzzle through `MockHandler`. The MCP connector expectation was updated for the removed header.

Verified on PHP 8.4: `tests/HttpClient` and `tests/MCP` pass, PHPStan reports no errors, and php-cs-fixer finds nothing to fix in the touched paths. The full suite passes except for the Calculator toolkit tests, which fail only because the local environment lacks ext-bcmath.

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces breaking changes (explain below)

## Documentation

- [ ] No documentation changes needed
- [x] I have updated relevant documentation
- [ ] Documentation will be updated in a separate PR
- [ ] New documentation needs to be created

## Checklist

- [x] My code follows the project's coding standards (PHPStan)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] My commit messages are clear and descriptive
- [x] This PR addresses only ONE specific goal/issue

## Additional Notes

The value is a hand-maintained constant, so it needs a bump when the next major starts. The `NeuronAI-Agent` header in the tool-authoring skill example was left alone on purpose: it identifies the user's application, not the framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UshYhDDJA2ChZsghoqgbG9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UshYhDDJA2ChZsghoqgbG9)_