### PR TITLE
Condense module AGENTS.md files to architecture and design decisions

### DIFF
--- a/src/Agent/AGENTS.md
+++ b/src/Agent/AGENTS.md
@@ -1,434 +1,108 @@
 # Agent Module
 
-AI agent built on Workflow. Provides chat, streaming, and structured output modes.
+`Agent` is a `Workflow` whose graph implements the agentic loop: instructions + history + tools → inference → tool execution → inference again → final response, in chat, streaming and structured-output modes. Study it as the reference composition; extend it, swap its nodes, or use it as a node inside your own workflow.
 
-**Dependencies**: `src/Workflow/AGENTS.md`, `src/Chat/AGENTS.md`, `src/Providers/AGENTS.md`, `src/Tools/AGENTS.md`
+## Defining an agent
 
-## Extension Pattern (Recommended)
-
-Create a custom agent class extending `Agent`:
+The extension pattern: lazy hooks provide the collaborators, so an agent class is a complete, self-describing unit.
 
 ```php
 use NeuronAI\Agent\Agent;
-use NeuronAI\Chat\Messages\SystemMessage;
-use NeuronAI\Providers\AIProviderInterface;
-use NeuronAI\Providers\Anthropic\Anthropic;
 
 class YouTubeAgent extends Agent
 {
     protected function provider(): AIProviderInterface
     {
-        return new Anthropic(
-            key: env('ANTHROPIC_API_KEY'),
-            model: 'claude-sonnet-4-6',
-        );
+        return new Anthropic(key: env('ANTHROPIC_API_KEY'), model: 'claude-sonnet-4-6');
     }
 
     protected function instructions(): SystemMessage|string
     {
-        return new SystemMessage(
-            <<<PROMPT
+        return new SystemMessage(<<<PROMPT
             You are an AI agent specialized in writing YouTube video summaries.
-
-            Get the URL of a YouTube video, or ask the user to provide one.
-            Use the tools you have available to retrieve the transcription of the video,
-            then write the summary.
-
-            Write the summary in a paragraph without using lists.
-            After the summary add a list of three sentences as the most important takeaways.
-            PROMPT
-        );
+            Use the tools you have available to retrieve the transcription, then write the summary.
+            PROMPT);
     }
 
     protected function tools(): array
     {
-        return [
-            GetTranscriptionTool::make(env('SUPADATA_API_KEY')),
-        ];
+        return [GetTranscriptionTool::make(env('SUPADATA_API_KEY'))];
     }
 }
 
-// Usage
-use NeuronAI\Chat\Messages\UserMessage;
-
-$response = YouTubeAgent::make()
-    ->chat(
-        new UserMessage('Summarize this: https://youtube.com/watch?v=...')
-    )
-    ->getMessage();
+$state = YouTubeAgent::make()->chat(new UserMessage('Summarize this: https://youtube.com/watch?v=...'));
+echo $state->getMessage()->getContent();
 ```
 
-`instructions()` can also return a plain string — it gets wrapped in a `SystemMessage`
-automatically. Call `->cache()` on the `SystemMessage` to mark its system content blocks
-for provider-side prompt caching.
+Every hook has a setter twin for fluent definition (`setAiProvider()`, `setInstructions()`, `addTool()`, `setChatHistory()`, `setMemory()`, `setPersistence()`), and an explicit setter wins over the hook. A plain string from `instructions()` is wrapped in a `SystemMessage`; `->cache()` marks its blocks for provider-side prompt caching. `SystemPrompt` is a small helper to compose a structured prompt (background, steps, output).
 
-## Fluent Definition (Alternative)
+| Verb | Nature |
+|---|---|
+| `chat($messages)` | Eager: runs to completion and returns `AgentState` |
+| `stream($messages)` | Pull-stream `Generator` of native chunks, or adapter lines; `getReturn()` is the `AgentState` |
+| `structured($messages, $class)` | Eager: returns the typed output |
+| `run($inputs = null, ...)` / `events(...)` | The Workflow terminals: no input starts a run, an explicit array continues one |
+| `toolApprovalDecisions($decisions)` | Stages approval decisions (sugar for `signal('approval', ...)`) for the following `run()` or `events()` |
 
-For quick prototyping or simple use cases:
+`AgentState::getMessage()` reads the final assistant message off the stored provider response; `isInterrupted()` / `getInterruptRequest()` surface an approval pause on the state itself, like any `WorkflowState`.
 
-```php
-use NeuronAI\Agent;
-use NeuronAI\Providers\Anthropic\Anthropic;
+## The graph is a function of the definition
 
-$agent = Agent::make()
-    ->setAiProvider(new Anthropic(key: '...', model: '...'))
-    ->setInstructions('You are a helpful assistant.')
-    ->addTool($tool);
+Default nodes are rebuilt through Workflow's `nodes()` hook at every execution segment, from the current configuration and never from which sugar method was called. Explicitly added nodes and registered middleware stay attached; custom node construction that must read configuration belongs in `nodes()` / `entryNodes()`.
 
-$response = $agent->chat(new UserMessage('Hello'))->getMessage();
+```text
+AgentStartEvent ─► StartNode ─► [RecallMemoryNode] ─► AIInferenceEvent ─► ChatNode ─────────────────┐
+ (messages+options)                                 or StructuredInferenceEvent ─► StructuredOutputNode ├► ToolNode ⟲
+                                                                                                      │ final response
+                                                                                     [StoreMemoryNode] ─► Stop
 ```
 
-## The static graph & execution intent
-
-The Agent builds fresh default nodes through Workflow's `nodes()` hook at each
-execution segment. The graph is a function of the current agent definition,
-never of which sugar method was called:
-
-```
-AgentStartEvent ─► StartNode ─► [RecallMemoryNode] ─► AIInferenceEvent ─► ChatNode ─┐
- (messages+intent)                 when requested      or StructuredInferenceEvent     ├► ToolNode ⟲
-                                                       ─► StructuredOutputNode ───────┘
-                                                                     │ final response
-                                                                     ▼
-                                                       [StoreMemoryNode] ─► Stop
-                                                          when requested
-```
-
-Fluent configuration changes take effect when the next segment bootstraps:
-provider, instructions, tools and toolkit guidelines, tool limits and error handling,
-parallel tool execution, history, and memory are injected into fresh nodes. Tools
-are expanded again for that segment. Explicitly added nodes and registered
-middleware remain attached; custom node construction belongs in `nodes()` or
-`entryNodes()` when it must read current configuration. RAG's entry chain follows
-the same lifecycle.
-
-Each `chat()`, `stream()`, or `structured()` call creates a fresh start event through
-the `startEvent()` hook, so inference settings do not leak between turns. A resume
-uses the recorded event intent and instructions with the currently configured live
-capabilities. Configuration changes during an active segment apply to the next
-segment; history replacement remains forbidden while executing.
-
-- `AgentStartEvent` carries public `messages` and `options` properties. Its
-  `AgentRunOptions` contains `stream`, `outputClass`, `maxRetries`, `recallMemory`,
-  and `rememberMemory`. All are mutable, typed properties. Framework nodes preserve
-  mode and memory policy within a run by convention; there is no immutable API.
-- `StartNode` initializes the public typed `AgentState::$request` from the start
-  messages and options, cloned instructions, and the effective tool list. RAG
-  initializes it in `PreProcessNode`, before retrieval. A fresh entry replaces the
-  previous request; before entry, the property is uninitialized.
-- `AIInferenceEvent`, `StructuredInferenceEvent`, and `RecallMemoryEvent` are routing
-  signals. `ToolCallEvent` carries only the tool-call message. Nodes and middleware
-  read and mutate the same `state->request`; events never forward it.
-  `AIInferenceEvent::fromRequest()` chooses the exact routing class from
-  `request->options->outputClass`. Memory recall enriches the request before routing.
-- Chat vs stream is transport: `ChatNode` reads `request->options->stream`. Both
-  paths record the same memoized `ProviderResponse`. Structured output retains its
-  dedicated node and attempt-indexed memos. `maxRetries` counts retries after the
-  first attempt: `0` disables retries, `1` allows two attempts; negatives act as `0`.
-- The tool loop replaces `request->messages` with the uncommitted tool call/result
-  pair (only the result when approval already committed the call), then routes the
-  same request back to inference. Those messages are combined with stored history;
-  changing them does not overwrite chat history.
+- Each `chat()` / `stream()` / `structured()` builds a fresh `AgentStartEvent` (`startEvent()` hook) carrying `messages` and `AgentRunOptions` (`stream`, `outputClass`, `maxRetries`, `recallMemory`, `rememberMemory`), so inference settings never leak between turns. Configuration changes during a segment apply to the next one.
+- `StartNode` initializes the public typed `AgentState::$request` (`InferenceRequest`: instructions, messages, tools, options) from the start event, cloned instructions and the effective tool list. **Nodes and middleware read and mutate that one request; events are routing signals and never forward it.** `AIInferenceEvent::fromRequest()` picks the exact routing class from `options->outputClass`.
+- Chat vs stream is transport: `ChatNode` reads `options->stream`, and both paths record the same memoized `ProviderResponse`. Structured output keeps its own node with attempt-indexed memos; `maxRetries` counts retries after the first attempt.
+- The tool loop replaces `request->messages` with the uncommitted call/result pair and routes the same request back to inference; those messages are combined with stored history, never overwrite it. `parallelToolCalls(true)` swaps `ToolNode` for `ParallelToolNode`.
+- The effective tool list is shared by inference and tool execution. Executable tools are excluded from request serialization (they may hold closures or connections): `Agent::restoreState()` re-seeds `bootstrapTools()` on recalled state, and tool-contributing middleware reapply their changes in `before()`. Cloning `AgentState` deep-copies messages, instructions and options, so parallel branches cannot affect each other.
 
 Middleware edits the working request directly:
 
 ```php
 $state->request->instructions->addContent($context);
 $state->request->tools[] = $tool;
-$state->request->messages = [$message];
 ```
 
-The effective tool list is shared by inference and tool execution. State snapshots
-persist the request's instructions, pending messages, and options. Request
-serialization excludes executable tools, which can hold closures or connections.
-`Agent::restoreState()` reattaches the current base registry whenever saved state
-re-enters the workflow; middleware reapply additions and removals before the
-relevant node executes. Live state never passes through this hook.
+### Middleware
 
-Cloning `AgentState` deeply copies request messages, instructions, and options so
-parallel branches cannot change one another's request data. Each clone retains its
-own tool selection array with references to the live tools; execution binds call
-inputs onto a clone of the selected tool. Providers, history, and memory remain
-constructor-injected services rather than persisted state.
-
-| Method | Effect |
-|--------|--------|
-| `chat($messages)` | Eager: ignites and runs to completion → `AgentState` (buffered transport) |
-| `stream($messages)` | Pull-stream: a `Generator` yielding native chunks or lines from the Workflow's configured adapter; `getReturn()` is the `AgentState`. |
-| `structured($messages, $class)` | Eager: returns the typed output |
-| `run($inputs = null, $expectedRunId = null, $expectedAttempt = null)` | Eager Workflow terminal: no input starts a run; an explicit array continues one. |
-| `events($inputs = null, $expectedRunId = null, $expectedAttempt = null)` | Pull-stream Workflow terminal; `getReturn()` is the `AgentState`. |
-| `toolApprovalDecisions($decisions)` | Stages approval decisions by tool call ID for the following `run()` or `events()`. |
-
-```php
-// Chat (eager → AgentState)
-$state = YouTubeAgent::make()->chat(new UserMessage('Hello'));
-echo $state->getMessage()->getContent();
-
-// Streaming (Generator → AgentState via getReturn())
-foreach (YouTubeAgent::make()->stream(new UserMessage('Hello')) as $chunk) {
-    echo $chunk->content;
-}
-
-// Structured output
-$report = MyAgent::make()->structured($message, ReportSchema::class);
-
-// Resume an approval by thread ID and decisions alone.
-$state = MyAgent::make()
-    ->setChatHistory($history)
-    ->setPersistence($persistence)
-    ->toolApprovalDecisions(['call_123' => 'approve'])
-    ->run();
-echo $state->getMessage()->getContent();
-```
-
-**`run()` and `events()` express both start and continuation.** With no input they start a new run; an explicit input array continues the existing one. Use `run([])` to evaluate due deadlines or recover without delivering an answer. Agent approvals are staged with `toolApprovalDecisions()`; durable platform SDKs pass addressed `ResumeInput` values directly to `run()` or `events()`. The run's mode never needs restating: intent is persisted in the ignition record (see *Ignition & thread identity* below).
-
-`chat()` and `run()` are eager and return `AgentState`; `stream()` and `events()` are pull-stream verbs returning a `Generator`.
-Workflow's generic state contract binds the inherited execution methods to
-`AgentState`; Agent does not override `run()` or `events()` merely to narrow
-their return types.
-`AgentState::getMessage()` reads the final assistant
-message off the stored provider response; `isInterrupted()` /
-`getInterruptRequest()` surface an approval pause on the state itself, just
-like a plain `WorkflowState`.
-
-## Middleware (`Middleware/`)
-
-Register via `$workflow->addMiddleware(NodeClass::class, $middleware)`:
-
-| Middleware | Purpose |
-|------------|---------|
-| `TodoPlanning` | Injects todo planning capabilities |
-| `Summarization` | Adds conversation summarization |
-
-Middleware shapes events before a node acts; flow control and I/O belong to the nodes
-themselves (tool approval, previously a middleware, now lives in `ToolNode`).
-
-Node matching is subclass-aware (`instanceof`), so middleware registered for a
-class also applies to its subclasses. `ChatNode` (chat + stream transport) and
-`StructuredOutputNode` are both always registered — the event's exact class
-selects the route at traversal time. They share the `InferenceNode` base
-class, so register mode-agnostic inference middleware (`Summarization`,
-`TodoPlanning`, `ToolSearchMiddleware`) against `InferenceNode::class` to have
-it fire on whichever inference route the run takes.
-
-### `AgentMiddleware` — typed hooks for the agent context
-
-Extend `AgentMiddleware` and implement `beforeAgentNode(AgentNodeInterface $node,
-Event $event, AgentState $state)` / `afterAgentNode(...)`. On misattachment
-outside the agent context `onAgentContextMismatch()` fires instead — empty by
-default, override it to fail loudly when a silent skip would be a hazard.
-Middleware read the chat history from the node they wrap
-(`$node->getChatHistory()`), never from their own constructor.
+Register with `addMiddleware(NodeClass::class, $middleware)`; matching is `instanceof`, so `InferenceNode::class` (the base of `ChatNode` and `StructuredOutputNode`, both always registered) is the target for mode-agnostic inference middleware such as `Summarization`, `TodoPlanning` and `ToolSearchMiddleware`. Extend `AgentMiddleware` for typed hooks: `beforeAgentNode()` / `afterAgentNode()` receive `AgentNodeInterface` and `AgentState`, and `onAgentContextMismatch()` fires on misattachment (empty by default, override it to fail loudly). Middleware read chat history from the node they wrap (`$node->getChatHistory()`), never from their own constructor. Flow control and I/O stay in nodes: tool approval, once a middleware, lives in `ToolNode`.
 
 ## Chat history is a service, not state
 
-The chat history is injected into agent nodes as a constructor dependency
-(`AgentNodeInterface`), never carried in `AgentState` — per-step snapshots stay
-O(1) instead of embedding the conversation. Consequences:
+History is injected into agent nodes as a constructor dependency (`AgentNodeInterface`), never carried in `AgentState`, so per-step snapshots stay O(1) instead of embedding the conversation. Consequences:
 
-- History writes go through `addToChatHistory($messages, $memo)`, which wraps
-  the write in a durable memo so a crash-replay skips it instead of duplicating
-  the tail.
-- A message commits only when the step that consumes it succeeds: inference
-  nodes commit their inbound after the provider call lands, and a non-gated
-  tool cycle commits the call/result pair together through the *next*
-  inference's inbound write — a tool crash or failed follow-up call
-  leaves the tail at the last committed message, never at a dangling tool call.
-  Only an approval-gated cycle writes its `ToolCallMessage` early (pre-suspend).
-- Durable workflow persistence requires a comparably durable chat history
-  (`InMemoryChatHistory` loses the thread across processes).
-- `AgentState::getMessage()` reads the final message off the stored provider
-  response; `AgentState::getSteps()` reports the current execution cycle's
-  messages only (transient, available even on an interrupted final state).
+- Writes go through `addToChatHistory($messages, $memo)`, a durable memo, so a crash-replay skips the write instead of duplicating the tail.
+- A message commits only when the step that consumes it succeeds: inference nodes commit their inbound after the provider call lands, and a non-gated tool cycle commits the call/result pair through the *next* inference's write. A tool crash or a failed follow-up call leaves the tail at the last committed message, never at a dangling tool call. Only an approval-gated cycle writes its `ToolCallMessage` early, pre-suspend.
+- Durable workflow persistence needs a comparably durable history: `InMemoryChatHistory` loses the thread across processes.
+- `AgentState::getSteps()` reports the current execution cycle's messages only (transient, available even on an interrupted state).
 
-### Memory-aware history wiring
+## Memory
 
-`SemanticMemory` is the ready-to-use vector-backed implementation. It reuses
-the RAG vector-store and embeddings interfaces. Give it a dedicated collection
-or index using the default `DocumentSchema`: the built-in `sourceType` and
-`sourceName` fields isolate memory documents by type and thread, so no custom
-schema is needed. A shared store whose schema declares other required metadata
-fields will reject memory documents that do not contain them.
+`MemoryInterface` (`recall(query)`, `remember(threadId, user, assistant)`, `forget(threadId)`) is the customization boundary: each implementation owns its retrieval scope. `SemanticMemory` is the vector-backed one, reusing the RAG store and embeddings interfaces with the default `DocumentSchema` (`sourceType` / `sourceName` isolate memory documents by type and thread, so give it a dedicated collection). Its `recallThreadIds` is an explicit allowlist, the current thread is not added implicitly, and it must come from trusted application data: never accept thread IDs from a client without an ownership check.
 
-```php
-use NeuronAI\Agent\Memory\SemanticMemory;
-use NeuronAI\Chat\History\FileChatHistory;
-use NeuronAI\RAG\Embeddings\OpenAIEmbeddingsProvider;
-use NeuronAI\RAG\VectorStore\FileVectorStore;
+Memory attaches independently of history (`memory()` hook or `setMemory()`), and `getChatHistory()` always returns the developer's exact instance; memory never wraps or proxies it. When attached, `RecallMemoryNode` runs once per turn before the first provider call (memoized; recalled strings are appended as a trailing `<CONVERSATION-MEMORIES>` system block and never enter history) and `StoreMemoryNode` stores the plain user/assistant exchange after the final response (tool traffic excluded; failed or interrupted turns store nothing). Both yield `memory.recall` / `memory.store` step events and emit count-only observability events. Inference nodes know nothing about memory, and a memory-free agent keeps its original graph.
 
-class MyAgent extends Agent
-{
-    protected function provider(): AIProviderInterface {...}
+`setMemoryUsage(recall:, remember:)` sets per-run intent for the two branches (a disabled branch is not traversed), and a suspended run resumes with its original choices. Working history and long-term memory share thread identity but have separate lifecycles: `flushAll()` clears only history (so `Summarization` can compact the context window), while `resetConversation()` forgets memory first and then clears history, leaving history untouched if forgetting fails.
 
-    protected function memory(): ?MemoryInterface
-    {
-        return new SemanticMemory(
-            vectorStore: new FileVectorStore(
-                directory: storage_path('app/agent-memory'),
-            ),
-            embeddings: new OpenAIEmbeddingsProvider(
-                key: env('OPENAI_API_KEY'),
-                model: 'text-embedding-3-small',
-            ),
-            topK: 5,
-            recallThreadIds: [...]
-        );
-    }
+## Tool approval
 
-    protected function chatHistory(): ChatHistoryInterface
-    {
-        return new FileChatHistory('path/directory');
-    }
-}
-
-$state = SupportAgent::make(threadId: $threadId)->chat(...);
-```
-
-`recallThreadIds` is the exact, non-empty recall allowlist owned by that
-`SemanticMemory` instance; the current thread is not added implicitly. Resolve
-the list from trusted application data, such as conversations owned by the
-authenticated user, and never accept thread IDs from a client without an
-ownership check. Duplicate IDs are removed.
-
-Recall searches the allowed threads together and applies `topK` globally.
-`remember()` and `forget()` remain scoped to one explicit thread, so completed
-exchanges are always stored in the current conversation and
-`resetConversation()` deletes only that conversation.
-
-`MemoryInterface` is the customization boundary: `recall()` receives only the
-query and returns relevant conversation excerpts, so each implementation owns
-its retrieval scope. `remember()` stores a completed exchange in one thread,
-and `forget()` removes one thread. Implement it directly for a non-vector
-backend.
-
-`setMemory(MemoryInterface $memory)` attaches memory independently from chat
-history, like every other Agent component. `getChatHistory()` always returns
-the exact developer-provided history instance; memory does not wrap, replace,
-or proxy it. Calling `setMemory()` before or after `setChatHistory()` produces
-the same result.
-
-`setMemoryUsage(recall: bool, remember: bool)` independently controls the two
-branches for each new run. Both default to true, preserving the normal
-recall-before-inference and remember-after-inference behavior. For example,
-keep writing memories while honoring a user's per-turn recall preference:
-
-```php
-$agent
-    ->setMemory($memory)
-    ->setMemoryUsage(
-        recall: $user->allowsMemoryRecall(),
-        remember: true,
-    )
-    ->chat($message);
-```
-
-Use `setMemoryUsage(recall: false)` for remember-only,
-`setMemoryUsage(remember: false)` for recall-only, or set both false to skip
-memory for the run while keeping the component attached. The choices are run
-intent: they can change between turns, survive structured routing and tool
-loops, and a suspended run resumes with its original choices. Memory nodes
-are included whenever memory is attached, but disabled branches are not
-traversed and emit no stream or observability events.
-
-Subclasses may provide the dependency through the lazy hook instead:
-
-```php
-protected function memory(): ?MemoryInterface
-{
-    return new ProjectMemory(/* ... */);
-}
-```
-
-An explicit `setMemory()` call wins over the hook. Memory can be added or replaced
-between interactions; the next segment injects the current component into its nodes.
-
-`RecallMemoryNode` runs after instructions are complete and before the first
-provider call. Recall is durably memoized there. Recalled strings are appended to a trailing
-`<CONVERSATION-MEMORIES>` system block; they never enter chat history. This
-works for chat, stream, structured output, and RAG without route-specific
-configuration. Tool iterations return directly to inference, so recall runs
-once per turn rather than once per tool call.
-
-The node yields `StepStartedStreamEvent('memory.recall')` and a matching
-`StepFinishedStreamEvent` around that work. The finished event reports only the
-number of recalled memories, never their content or thread IDs.
-
-After the final inference writes its response to chat history, a
-`StoreMemoryEvent` routes the completed message slice through
-`StoreMemoryNode`. The node extracts the plain user-assistant exchange and
-memoizes `remember()` as its own durable side effect. Tool-assisted turns are
-stored only after their final assistant response; `ToolCallMessage` and
-`ToolResultMessage` remain protocol traffic and are excluded. Failed
-inference, incomplete streams, and interrupted tool loops produce no memory.
-The store node similarly yields `memory.store` step started/finished events.
-These portable events are visible in a native stream and are translated by
-AG-UI or Vercel adapters without either adapter depending on memory classes.
-
-Memory operations also emit PSR-14 observability pairs around the actual memory
-boundary: `MemoryRecalling` / `MemoryRecalled` and `MemoryStoring` /
-`MemoryStored`. The recall completion event exposes only the recalled-memory
-count; it never exposes queries, recalled content, retrieval scope, or thread
-IDs. The existing `WorkflowNodeStart` / `WorkflowNodeEnd` events still describe
-generic node execution. If a memory operation throws, its starting event is
-followed by the existing `AgentError` and no successful completion event.
-
-Inference nodes do not depend on `MemoryInterface` and perform no recall,
-prompt injection, pair extraction, or storage. They only route final responses
-to the store phase when remembering is requested and memory is available. The
-Agent adds the recall and store nodes only when memory is configured, so a
-memory-free Agent keeps its original graph and execution cost. Implement
-`MemoryInterface` to customize recall, redaction, or persistence.
-
-Chat history and long-term memory share thread identity, but they have separate
-lifecycles. `ChatHistoryInterface::flushAll()` clears only working history.
-This allows `Summarization` and custom middleware to compact or rewrite the
-context window without deleting durable semantic memories.
-
-Use the explicit aggregate operation when the user intends to permanently
-delete the entire conversation:
-
-```php
-$agent->resetConversation();
-```
-
-`resetConversation()` calls `MemoryInterface::forget($threadId)` first, when
-memory is configured, and then clears chat history. If forgetting fails, chat
-history remains untouched and the exception propagates. Without configured
-memory, it simply clears chat history.
-
-## Persistence & Tool Approval
-
-`ToolNode` gates tool execution behind human approval — there is no middleware
-to attach; the gate runs on every tool call and asks each tool. Messages carry `ToolCall`
-value objects: the node resolves every call against ONE source — the inference
-state request's tool list, the cycle's effective set (agent base plus middleware additions, minus
-middleware removals) — clones the match, binds the call's inputs, executes, and settles
-the result back onto the call. A call naming a tool outside that set throws a
-`ToolException`. Exceptions escaping tool execution are bugs and propagate (a
-*conversational* failure is a returned `ToolOutput::error()` — see
-`src/Tools/AGENTS.md`); `toolErrorHandler(fn (Throwable $e, ToolCall $call):
-string|ToolOutput|null)` is the cross-cutting override — a returned string or
-`ToolOutput` settles as the call's result, `null` declines and the exception
-propagates. Executable tools are transient in state persistence: the executor passes
-recalled state through `Workflow::restoreState()` before it re-enters traversal.
-The Agent override re-seeds `bootstrapTools()` on the recorded request. Live state
-never passes through restoration, so middleware additions and removals remain in
-effect during ordinary transitions. Tool-contributing middleware reapply their
-changes in `before()`. The node itself holds no tool registry. **Each tool declares** its
-intrinsic risk via the protected `approvalPolicy(array $inputs)` hook, and the agent
-developer overrides the declaration per tool at
-attach time, in both directions:
+`ToolNode` gates execution: on every call it asks each tool `requiresApproval(inputs)` (declaration and attach-time overrides, see `src/Tools/AGENTS.md`), resolves the call against the request's tool list (a `ToolException` for anything else), clones the match, binds the inputs, executes under a durable memo, and settles the result on the `ToolCall`. Escaped exceptions are bugs and propagate unless `toolErrorHandler()` converts them.
 
 ```php
 protected function tools(): array
 {
     return [
-        DeleteFileTool::make()->requireApproval(),        // force, even if it declares false
-        RiskyThirdPartyTool::make()->suppressApproval(),  // waive a declared gate
-        TransferMoneyTool::make()->withApprovalPolicy(    // replace the policy
-            fn (ToolInterface $t): bool|string => ($t->getInputs()['amount'] ?? 0) > 100
+        DeleteFileTool::make()->requireApproval(),
+        RiskyThirdPartyTool::make()->suppressApproval(),
+        TransferMoneyTool::make()->withApprovalPolicy(
+            fn (ToolInterface $tool): bool|string => ($tool->getInputs()['amount'] ?? 0) > 100
                 ? 'Transfers above $100 require a human sign-off'
                 : false
         ),
@@ -436,24 +110,7 @@ protected function tools(): array
 }
 ```
 
-Both the declaration and a policy callback return `bool|string` — a string counts as `true`
-and doubles as the approval reason shown to the approver (persisted as `approvalReason` on
-the tool entry in chat history, exposed on the `ApprovalRequest` actions as `reason`). When
-a gated tool is requested, `chat()` returns suspended instead of completed — cross-process
-flows require **workflow persistence AND a durable chat history** (the suspend-time
-`ToolCallMessage` in chat history is what lets a cold process render and resume the pending
-approval).
-
-```php
-use NeuronAI\Workflow\Persistence\DatabasePersistence;
-
-$agent = YouTubeAgent::make()
-    ->setPersistence(new DatabasePersistence($pdo));
-    // + a durable ChatHistory
-```
-
-A continuation delivers decisions as a **cumulative** payload keyed by tool callId — the entire
-decision set, restated on every continuation:
+When a gated tool is requested, `chat()` returns suspended. A continuation delivers decisions as a **cumulative** payload keyed by call ID, restated in full on every continuation:
 
 ```php
 $agent->toolApprovalDecisions([
@@ -462,108 +119,14 @@ $agent->toolApprovalDecisions([
 ])->run();
 ```
 
-A tool runs iff explicitly approved; silence is never consent. An incomplete payload
-re-suspends, and partial decisions are deliberately **not** persisted anywhere —
-accumulation lives with the caller (an app collecting decisions one at a time gathers
-them itself before resuming). The latest payload wins, so decisions are revisable until
-the set completes. The UI re-renders pending approvals by reading chat history (last
-message, tools with `getApprovalState()`) — no workflow boot; final outcomes are read
-from the `ToolResultMessage` that follows. The thread stays effectively
-**locked** until the full decision set is delivered — the engine's
-one-live-run-per-workflow-ID refusal (see *Thread-first continuation* below)
-blocks any new turn until the pending approvals are settled.
+A tool runs iff explicitly approved: silence is never consent, an incomplete payload re-suspends, and partial decisions are deliberately not persisted anywhere (accumulation lives with the caller, and the latest payload wins). A UI re-renders pending approvals from chat history alone (last message, tools with `getApprovalState()`) with no workflow boot; final outcomes are read from the following `ToolResultMessage`. Cross-process flows need workflow persistence **and** a durable chat history.
 
-### Leases: surviving a killed process
+## The thread IS the workflow ID
 
-Every Agent run holds a **ten-minute lease** by default (`leaseTimeout()`).
-A caught failure records `failed` and the next turn supersedes it, but a
-process killed with no chance to write (memory limit, `max_execution_time`,
-an OOM-killed container) leaves the thread `running`, and nothing can tell
-that apart from a live worker. The lease resolves it: every step commit
-renews a deadline, so once it passes the next `chat()` supersedes the dead
-run instead of refusing; until then the refusal names the deadline. Raise it
-above your slowest provider or tool call with `setLeaseTimeout()` or by
-overriding `leaseTimeout()`. `null` disables it, in which case a killed
-process strands the thread until `run([])` takes it over. The renewal rides
-on the step commit, so the lease costs no extra write.
-### Thread-first continuation: the thread IS the workflow ID
-
-The Agent declares its **threadId as the run's workflow ID** (`workflowId()`), so the
-run's durable records live in the partition named by the thread itself. There
-is no pointer and no index: the approve/deny endpoint needs only the thread
-id, one read answers "is a run in flight here", and nothing about execution
-identity ever touches chat history:
+The Agent declares its `threadId` as the run's workflow ID (`workflowId()`), so a run's durable records live in the partition named by the thread. No pointer, no index: the approve endpoint needs only the thread ID, one read answers "is a run in flight here", and execution identity never touches chat history.
 
 ```php
-// New execution cycle: nothing stored anywhere by the application — the
-// thread IS the workflow ID. The history is constructed WITHOUT identity; the
-// framework binds the resolved threadId into it.
-$agent = Agent::make(threadId: $threadId)
-    ->setChatHistory(new SQLChatHistory($pdo))
-    ->setPersistence($persistence);
-
-$agent->toolApprovalDecisions(['call_123' => 'approve'])
-    ->run();
-// (a pre-bound history — new SQLChatHistory($pdo, $threadId) — declares the
-// same identity by adoption and works identically)
-```
-
-The decision-map form specifically resolves Agent tool approval. Ordinary
-Workflow event waits use `signal()`, due timers use `run([])`, and a
-platform can address any interruption type with `ResumeInput`. One live run per
-thread is enforced by the engine: a new `chat()` while a run is suspended on the
-thread is **refused** loudly with a `RunInFlightException` that names the pending
-`approval` event and carries the `ApprovalRequest` in `interrupts`; settle the
-pending run first — typically `toolApprovalDecisions()` followed by `run()` with decline decisions. A continuation
-that can identify no run at all (no workflow ID, nothing in flight) throws a
-`WorkflowException` rather than running against the wrong one.
-
-A *failed* turn does not lock the thread. A provider outage or a crashed tool
-commits `failed` under the thread; the inbound message was never written to
-history, so nothing dangles. The next `chat()` supersedes the dead generation
-and starts a fresh turn with whatever messages it carries. Call `run([])`
-instead to replay the failed turn as it was, reusing every memoized step (a
-long tool loop is not re-billed). See *Failed and dead generations* in
-`src/Workflow/AGENTS.md`.
-
-`abandonRun()` discards a dead turn without starting a new one (a "dismiss"
-action) and returns false when nothing is in flight. It **refuses while an
-approval is pending**: the pre-suspend `ToolCallMessage` would be left
-unanswered in history and every provider rejects the next turn, so settle the
-approval with `toolApprovalDecisions()` instead. `resetConversation()` frees
-the thread unconditionally, since it wipes the history anyway.
-
-The declared workflow ID is `null` while no thread identity has been declared —
-the run then lives under an engine-generated workflow ID (`getWorkflowId()` after the
-first segment) and the threadId, if any, arrives from the ignition record.
-See `src/Workflow/AGENTS.md` for the workflow ID model and the identity truth
-table.
-
-## Ignition & thread identity
-
-The **Agent owns its thread identity**: `Agent::getThreadId(): ?string` is a
-nullable slot validated by `adoptThreadId()` during implicit adoption. An explicit
-`setChatHistory()` call with a different pre-bound history selects a new conversation.
-The framework **never generates** a thread identity — it is always a developer statement, and a run without one
-is simply not findable by its thread (`workflowId()` null, generated workflow ID, no
-`threadId` in the ignition record).
-
-**Collaborators are bound, not identity-constructed.** Chat histories are
-thread-scoped by nature but constructible *without* their thread
-(`ChatHistoryInterface::setThreadId()` / `getThreadId(): ?string`; loading is
-lazy): the Agent binds the resolved identity into an unbound history before
-first use. Wiring code can therefore leave identity to the caller:
-
-```php
-class SupportAgent extends Agent
-{
-    protected function chatHistory(): ChatHistoryInterface
-    {
-        return new SQLChatHistory($this->pdo, contextWindow: 50000);   // identity: not your job
-    }
-}
-
-// Fresh turn (a controller): identity enters through the ONE front door.
+// Fresh turn (controller): identity enters through the one front door.
 SupportAgent::make(threadId: $threadId)->chat(new UserMessage($input));
 
 // Thread-first resume (approve endpoint): same statement.
@@ -571,72 +134,20 @@ SupportAgent::make(threadId: $threadId)
     ->toolApprovalDecisions(['call_123' => 'approve'])
     ->run();
 
-// WorkflowId-first resume (background wake): the record supplies the thread
-// identity — the developer writes nothing.
-SupportAgent::make(workflowId: $ticket->workflowId)->run(
-    [ResumeInput::fromArray($ticket->input)],
-    expectedRunId: $ticket->runId,
-);
+// WorkflowId-first resume (background wake): the ignition record supplies the thread.
+SupportAgent::make(workflowId: $ticket->workflowId)
+    ->run([ResumeInput::fromArray($ticket->input)], expectedRunId: $ticket->runId);
 ```
 
-Implicit identity adoption rejects disagreeing non-null claims (`AgentException`).
-An explicit history setter selects the conversation instead:
+Identity is **always a developer statement; the framework never generates one**. It resolves from `make(threadId:)`, from adoption of a pre-bound history passed to `setChatHistory()` (which selects that conversation), or from the ignition record on a workflowId-first resume. Disagreeing non-null claims throw `AgentException`: a record contradicting an explicit claim is a misidentified continuation. Once resolved, the Agent binds the identity into an unbound history (`setThreadId()`, itself assign-once). A run without identity lives under an engine-generated workflow ID and is simply not findable by its thread; a hook-provided history that self-keys materializes after the ignition record is written, so it does not make a run thread-findable either.
 
-1. **Explicit**: `Agent::make(threadId: 'thread-42')`.
-2. **Adoption from a pre-bound history**: `setChatHistory(new SQLChatHistory($pdo, 'thread-42'))`
-   selects the history's key as the agent's identity, replacing the previous selection.
-3. **The ignition record** (workflowId-first resume): `applyIgnitionContext()`
-   adopts the recorded threadId — adoption validates, so a record
-   contradicting an explicitly claimed identity throws (a misidentified
-   continuation). The engine's own check fires even earlier: a declared
-   threadId disagreeing with an explicit `make(workflowId:)` is refused at
-   identity resolution.
+One live run per thread has these consequences:
 
-`setChatHistory()` can replace history between interactions, including after a
-completed, failed, or suspended turn. A different thread clears local workflow/run
-identity, state, start-event intent, and staged signals; persisted runs and both
-histories remain intact. Swap back to the original history to continue its suspended
-run. An unbound replacement adopts the current thread. The next segment constructs
-its agent nodes with the replacement history. Replacing history during an
-active execution or stream throws `AgentException`.
+- A new `chat()` while a run is suspended on the thread is refused with `RunInFlightException`, carrying the pending `ApprovalRequest`; settle it first. The thread stays locked until the full decision set is delivered.
+- A *failed* turn does not lock the thread: the inbound message was never written, so the next `chat()` supersedes the dead generation, while `run([])` replays it reusing every memoized step (a long tool loop is not re-billed).
+- Every Agent run holds a ten-minute lease (`leaseTimeout()` hook, `setLeaseTimeout()`, `null` disables), so a process killed mid-turn stops refusing the thread once the deadline passes. Raise it above your slowest provider or tool call.
+- `abandonRun()` dismisses a dead turn but refuses while an approval is pending, since the pre-suspend `ToolCallMessage` would be left unanswered in history; `resetConversation()` frees the thread unconditionally.
 
-**Thread-findability requires identity declared before the run starts** (the two
-sources above, or the record on a resume). A pre-bound *hook* history (the
-in-memory default self-keying, or a subclass hook choosing a fixed key) is
-adopted and validated when it materializes during bootstrap — but that is
-after the workflow ID is resolved and the ignition record written, so it does
-not make the run findable by its thread. `getThreadId()` is a pure read of the
-slot; hooks may consult it freely (null on anonymous runs).
+**Persisted wins.** Every durable run writes an ignition record at first execution: run ID, start event (messages + intent) and the context bag (`threadId`). On resume the record's intent and instructions win over the factory's current defaults: the factory supplies capability (provider, tools, history), the record supplies intent. `setChatHistory()` may replace history between interactions; a different thread clears local run identity and staged signals while persisted runs stay intact, and replacing it during an active execution throws.
 
-The moment identity resolves, the Agent binds it into an unbound history
-(`setThreadId()`, itself conflict-guarded: re-pointing a bound history at a
-different thread always throws). A durable history *used* while unbound
-fails loudly ("thread-scoped and no thread identity was given").
-
-Every durable run persists its **ignition record** at first execution: the
-runId (generation stamp), the start event (messages + intent), plus the
-Agent's context bag (`['threadId' => ...]`, read from the identity slot;
-omitted when anonymous). That is what makes a suspended run continuable from
-a **blank process** — a factory that knows only the workflow ID.
-
-- `setChatHistory()` accepts a `ChatHistoryInterface` (pre-bound = identity
-  declaration; unbound = the framework binds). `setChannel()` accepts a
-  concrete channel or null.
-- **Adapted stream delivery**: a `StreamingChannelInterface` has two ports —
-  `send(object)` for native chunks and `sendLine(string)` for protocol lines. With no
-  adapter attached, the channel receives native chunks via `send()`. Attach a stream
-  adapter via `setStreamAdapter($adapter)` and the workflow runs each yielded chunk through
-  it once. Pull iteration yields the resulting lines (including the adapter's
-  `start()`/`end()` framing), and an attached channel receives the same lines via
-  `sendLine()`. The adapter decides the output shape; the channel independently decides
-  the destination (Pusher, websocket, …). An adapter is stateful for one stream.
-- **Persisted-wins**: on a resume the recorded start event and context win over
-  the factory's defaults. Editing `instructions()` between suspend and resume
-  does not affect the resumed run — the record is the run's contract; the
-  factory supplies capability (provider, tools, history), the record supplies
-  intent.
-
-**Security note — threadId is untrusted input used as a storage key.** The
-frontend-supplied threadId selects which conversation is read, written, and
-resumed. Authorize user ↔ thread ownership BEFORE opening a history with it;
-the framework performs no access control.
+**Security.** The threadId is untrusted input used as a storage key: it selects which conversation is read, written and resumed. Authorize user ↔ thread ownership before opening a history with it; the framework performs no access control.

--- a/src/Chat/AGENTS.md
+++ b/src/Chat/AGENTS.md
@@ -1,157 +1,40 @@
 # Chat Module
 
-Unified messaging layer. Used by Agent, RAG, and Providers.
+The messaging layer shared by Agent, RAG and Providers: messages, content blocks, stream chunks and chat history. Self-contained.
 
-## Messages (`Messages/`)
+## Messages are content blocks
 
-Base `Message` class manages content as `ContentBlock[]`:
+`Message` manages `ContentBlock[]` (`TextContent`, `ImageContent`, `FileContent`, `AudioContent`, `VideoContent`, `ReasoningContent`, `SystemContent`), so multimodality is native rather than bolted on. `getContent()` is the text-only view; `getContentBlocks()` is the truth.
 
 ```php
-$message = new UserMessage([
+new UserMessage([
     new TextContent('Analyze this:'),
     new ImageContent('https://...', SourceType::URL, MediaType::JPEG),
 ]);
 ```
 
-| Class | Role |
-|-------|------|
-| `Message.php` | Base, manages `ContentBlock[]` |
-| `SystemMessage` | System instructions, carries `SystemContent` blocks (cacheable via `->cache()`) |
-| `UserMessage` | User input |
-| `AssistantMessage` | AI response |
-| `ToolCallMessage` | Tool invocation request — carries `ToolCall[]` (conversation data) |
-| `ToolResultMessage` | Tool execution result — the same `ToolCall[]`, settled with results |
+`SystemMessage` carries `SystemContent` blocks; `->cache()` marks them for provider-side prompt caching. `ToolCallMessage` (an `AssistantMessage`) and `ToolResultMessage` (a `UserMessage`) carry the same `ToolCall[]`: pure conversation data, settled with results in the second. Executable tools never appear in messages (see `src/Tools/AGENTS.md`). Content blocks accept `string|MediaType` for the media type and normalize to string, so custom MIME types always work.
 
-**Key methods**: `getContent()` (text only), `getContentBlocks()`, `addContentBlock()`
+## Chat history
 
-## Content Blocks (`Messages/ContentBlocks/`)
+`AbstractChatHistory` implements the logic once; backends persist through one protected hook per primitive mutation, append (`onNewMessage`), head-trim (`onTrimHistory`) and clear, or ignore the hooks and rewrite the whole state via `setMessages()` (File, InMemory). SQL and Eloquent backends store one row per message keyed by thread. `HistoryTrimmer` keeps the thread inside the context window by estimating tokens and dropping the oldest messages first.
 
-All implement `ContentBlock` interface:
+### Identity: histories are bound, not identity-constructed
 
-| Block | Usage |
-|-------|-------|
-| `TextContent` | Plain text |
-| `ImageContent` | Images (URL or base64) |
-| `FileContent` | Documents (PDF, etc.) |
-| `AudioContent` | Audio files |
-| `VideoContent` | Video files |
-| `ReasoningContent` | AI reasoning traces |
+A history is thread-scoped by nature but constructible *without* its thread: loading is lazy, so the Agent can bind the resolved thread ID into an unbound history before it is ever touched (`new SQLChatHistory($pdo)` in a hook, identity supplied once by `Agent::make(threadId:)`). The rules, implemented in `AbstractChatHistory`:
 
-Source types: `SourceType::URL` or `SourceType::BASE64`
+- `setThreadId()` is assign-once: the same id is a no-op, a different id throws `ChatHistoryException`. Re-pointing a conversation at another thread is never legitimate.
+- A durable backend *used* while unbound throws loudly, never a silent read of a wrong, empty thread.
+- Constructor identity is optional and positioned after the required dependencies (`new SQLChatHistory($pdo, 'thread-1')`); passing it pre-binds the history, which the Agent adopts as an identity declaration. `InMemoryChatHistory` self-keys when none is given.
 
-## Chat History (`History/`)
+Thread identity itself belongs to the Agent (`src/Agent/AGENTS.md`); the history only validates against it.
 
-Implementations of `ChatHistoryInterface`:
+### Invariants
 
-| Class | Storage |
-|-------|---------|
-| `InMemoryChatHistory` | Array (testing) |
-| `FileChatHistory` | JSON files |
-| `SQLChatHistory` | PDO database (one row per message, keyed by `thread_id`) |
-| `EloquentChatHistory` | Laravel Eloquent (one row per message, keyed by `thread_id`) |
+- **Alternation.** A plain `UserMessage` can never directly follow a `ToolCallMessage`: the calls must be answered by a `ToolResultMessage` first. `HistoryTrimmer::validateAlternation()` enforces it on every append, which also covers sequences loaded from storage; a custom `HistoryTrimmerInterface` takes over this responsibility.
+- **Append-only.** `addMessage()` always appends; there is no update or replace, so a direct `ChatHistoryInterface` implementation that appends is fully conformant. Write-once convergence under crash replay is the *writer's* job, not the store's: agent nodes wrap history writes in durable memos (`src/Agent/AGENTS.md`).
+- **Nothing dangles.** Messages commit only after the step that consumes them succeeds, so a failed provider call or a crashed tool never leaves a user message or tool call at the tail. The single exception is an approval-gated `ToolCallMessage`, written before the suspend so a cold process can render the pending approval from history alone.
+- **Approval is recorded on messages.** The `tool_call` message keeps its pending snapshot forever; the final outcomes (approved/rejected, feedback, results) live on the `ToolResultMessage` that follows. "Is approval pending?" is answered by the thread tail alone. Serialized tool entries carry `approval`, `approvalReason` (outbound, why the tool asked) and `rejectReason` (inbound, the approver's feedback); entries stored without these keys deserialize as not gated.
+- **No execution identity.** History records nothing about the workflow run that produced a message. Reattaching to a suspended run is the engine's job, keyed by the thread itself (`src/Workflow/AGENTS.md`).
 
-**Base**: `AbstractChatHistory` provides common logic. Subclasses persist through one
-protected no-op hook per primitive history mutation — append (`onNewMessage`), head-trim
-(`onTrimHistory`), clear (`clear`) — or ignore the granular hooks and rewrite the whole
-state via `setMessages()` (File, InMemory).
-
-**Identity — histories are bound, not identity-constructed**:
-`ChatHistoryInterface::setThreadId(string)` / `getThreadId(): ?string` (null until
-bound). A history is thread-scoped by nature but constructible *without* its thread —
-loading is **lazy** (deferred to first read/write), so the Agent can bind the resolved
-identity into an unbound history before it is ever touched. The rules, implemented once
-in `AbstractChatHistory`:
-
-- `setThreadId()` is assign-once in effect: same id → no-op; a *different* id →
-  `ChatHistoryException` (re-pointing a conversation at another thread is never
-  legitimate).
-- A durable backend **used** while unbound throws loudly ("thread-scoped and no thread
-  identity was given") — never a silent read of a wrong, empty thread.
-- Constructor identity is optional and positioned after required dependencies
-  (`new SQLChatHistory($pdo, 'thread-1')`, `new EloquentChatHistory(Model::class, 't')`,
-  `new FileChatHistory($dir, 'key')`): passing it *pre-binds* the history, which the
-  Agent treats as an identity declaration (adoption). `InMemoryChatHistory` self-keys
-  via `uniqid()` when none is given (its own storage default, not framework identity
-  fabrication).
-
-The framework's thread identity lives on the **Agent** (`Agent::getThreadId()`, see
-`src/Agent/AGENTS.md`). Implicit attachment validates the history's key against it;
-an explicit `setChatHistory()` call can select another conversation using a new history.
-
-### Message alternation
-
-A pure `UserMessage` can never directly follow a `ToolCallMessage` — the tool calls must be
-answered by a `ToolResultMessage` first (which itself extends `UserMessage` and is the expected
-continuation). Enforced by `HistoryTrimmer::validateAlternation()` (`ChatHistoryException`),
-which runs on every `addMessage()` append and therefore also covers sequences loaded from
-storage. This is pure sequence validation, independent of tool approval; note that a custom
-`HistoryTrimmerInterface` implementation takes over this responsibility.
-
-### Append-only history & tool approval
-
-`addMessage()` always appends — the history has no update or replace operation, so a
-direct `ChatHistoryInterface` implementation that appends is fully conformant.
-Write-once convergence lives with the single writer, not the store: when approval-gated
-tools are present, `ToolNode` writes the annotated `ToolCallMessage` (pending states)
-exactly once, through a durable memoized write, **before** any approval suspend —
-a resume or crash-replay pass skips the write instead of duplicating the
-tail. With no gated tools nothing is written there at all: the call/result pair travels
-as the next inference's inbound messages and commits together only after that provider
-call succeeds, so a tool crash or a failed follow-up call can never leave a
-dangling `tool_call` at the tail.
-
-The `tool_call` message keeps its pending snapshot forever; the **final approval
-outcomes** (approved/rejected + feedback + results) are recorded on the
-`ToolResultMessage` that follows it. "Is approval pending?" = the thread tail is a
-`tool_call` whose tools are pending.
-
-(Replay convergence for message writes is handled by the agent nodes' memoized
-history writes — see `src/Agent/AGENTS.md`.)
-
-Tool entries are `ToolCall` value objects (`NeuronAI\Tools\ToolCall`) — pure
-conversation data; executable tools never appear in messages. Serialized entries carry
-three approval fields: `approval` (`pending`|`approved`|
-`rejected`, or absent for a non-gated tool), `approvalReason` (outbound — why the tool is
-asking for approval, declared by the tool or its attach-time policy), and `rejectReason`
-(inbound — the approver's feedback, rejection-only). Old stored histories without these
-keys deserialize as `null` (not gated).
-
-A tool entry's `result` is a string, a content block array when the tool returned a
-multimodal `ToolOutput`, or `{is_error: true, blocks: [...]}` when it returned an
-error output (`ToolOutput::error()` — see `src/Tools/AGENTS.md`).
-`AbstractChatHistory::deserializeToolResult()` discriminates on shape — the `is_error`
-marker rebuilds an error `ToolOutput`, an array whose first element has a `type` key
-rebuilds a plain `ToolOutput` through the shared content block deserializer, anything
-else stays a string — so legacy stored histories deserialize unchanged (never carrying
-the marker, they come back as non-error).
-
-Chat history carries **no execution identity**. A suspended `ToolCallMessage` records
-the pending approval snapshot — enough to *render* a pending approval from history
-alone — and nothing about the workflow run that produced it. Reattaching to that run is
-the engine's job: the Agent declares its threadId as the run's address, so the
-run's durable records live under the thread itself (see
-`src/Workflow/AGENTS.md`). Old stored histories may still carry a `run_id` /
-`resume_token` metadata key; it deserializes into the generic metadata bag and is never
-read.
-
-### History Trimming
-
-`HistoryTrimmer` reduces token count when history exceeds limits:
-- Uses `TokenCounter` to estimate tokens
-- Preserves system messages
-- Removes oldest messages first
-
-## Enums (`Enums/`)
-
-- `ContentBlockType` - TEXT, IMAGE, FILE, AUDIO, VIDEO
-- `SourceType` - URL, BASE64
-- `MediaType` - common MIME types (JPEG, PNG, PDF, MP3, MP4, ...). Content blocks accept `string|MediaType` for `mediaType` and normalize to `string`, so custom MIME strings always work
-- `MessageRole` - USER, ASSISTANT, SYSTEM, TOOL
-
-## Stream (`Messages/Stream/`)
-
-Streaming message chunks for real-time responses.
-
-## Dependencies
-
-None. Chat is self-contained.
+A tool entry's `result` round-trips as a string, a content block array (a multimodal `ToolOutput`) or `{is_error: true, blocks: [...]}` for `ToolOutput::error()`; `deserializeToolResult()` discriminates on shape, so legacy stored histories come back unchanged.

--- a/src/Chat/Messages/Stream/Adapters/AGENTS.md
+++ b/src/Chat/Messages/Stream/Adapters/AGENTS.md
@@ -1,207 +1,54 @@
 # Stream Adapters
 
-This directory contains the protocol boundary between Neuron's native streamed
-objects and UI transports such as AG-UI and the Vercel AI SDK data stream.
+The protocol boundary between Neuron's native streamed objects and UI transports such as AG-UI and the Vercel AI SDK data stream.
 
 ## Ownership and layering
 
-`StreamAdapterInterface` currently lives under `Chat` for public API
-compatibility, but the capability is consumed by the underlying `Workflow`:
+`StreamAdapterInterface` lives under `Chat` for public API compatibility, but the capability is consumed by `Workflow`, and it must stay free of Agent- and memory-specific concepts so custom workflows can use it:
 
-- a node may yield any object as intermediate, live output;
-- `Workflow::events()` exposes native objects when no adapter is configured;
-- `setStreamAdapter()` makes Workflow convert output to protocol lines once;
-- pull consumers receive those lines, and an attached streaming channel
-  receives the same lines through `sendLine()`;
-- `Agent::stream($messages)` only records streaming intent and yields Workflow
-  output.
+- a node may `yield` any object as live, intermediate output, and must still `return` its routing event;
+- `Workflow::events()` exposes the native objects when no adapter is configured;
+- `setStreamAdapter()` makes the Workflow convert output to protocol lines **once**: pull consumers receive those lines, and an attached `StreamingChannelInterface` receives the same lines through `sendLine()`;
+- `Agent::stream()` only records streaming intent and yields Workflow output.
 
-Do not combine changes to this feature with a namespace move. A namespace move
-would be a separate breaking-change decision. Keep the portable abstraction free
-of Agent-specific and memory-specific concepts so custom workflows can use it.
+An adapter is stateful for one stream; never share an instance between concurrent streams. `SSEAdapter` owns only common SSE formatting and ID generation; protocol state and payloads belong to the concrete adapters.
 
-## Current adapter contract
+## Contract
 
-`StreamAdapterInterface` has four operations:
-
-- `start()` emits optional protocol framing;
-- `transform(object $chunk)` converts one yielded object into zero or more
-  strings;
-- `end()` emits optional protocol termination on completion or suspension;
-- `error(Throwable $error)` emits optional failure and termination frames instead
-  of `end()` when streaming fails. Custom adapters receive the original exception
-  and own its protocol representation; return `[]` if no failure output is needed.
-
-Adapters are stateful for one stream. Never share one adapter instance between
-two concurrent streams. Pull and push delivery from one Workflow execution use
-the same transformation and therefore the same instance by design.
-
-`SSEAdapter` owns only common SSE formatting and ID generation. Protocol state
-and protocol payloads belong in the concrete adapters.
-
-### Existing protocol behavior
-
-| Adapter | Run/message framing | Native chunks |
-|---|---|---|
-| `AGUIAdapter` | `RUN_STARTED` / `RUN_FINISHED` or `RUN_ERROR`, with separate text and reasoning lifecycles | text, reasoning, tool arguments, tool calls, tool results |
-| `VercelAIAdapter` | lazy `start`, then `finish` and `[DONE]`; failures emit `error` and `[DONE]` | text, reasoning, tool arguments, tool calls, tool results |
-
-Unknown objects are currently ignored. Preserve that behavior for objects that
-are neither recognized portable stream events nor explicitly mapped developer
-events.
+`start()` (optional framing), `transform(object $chunk)` (one object → zero or more strings), `end()` (termination on completion or suspension) and `error(Throwable $error)` (failure frames instead of `end()`; return `[]` when the protocol has none). The Workflow calls `error()` itself for failures during streamed execution or chunk transformation; the channel still receives `failed()` and the exception is rethrown to the caller. After `error()` an adapter emits no further frames.
 
 ## Portable stream events
 
-Nodes should be able to yield protocol-neutral UI information without importing
-AG-UI or Vercel types:
+Nodes yield protocol-neutral UI information without importing AG-UI or Vercel types:
 
 ```text
-workflow domain event
-        | exact-class mapper (optional)
-        v
-portable StreamEventInterface
-        | concrete adapter
-        v
-AG-UI event or Vercel data part
+workflow domain event → exact-class mapper (optional) → StreamEventInterface → AG-UI event | Vercel data part
 ```
 
-The initial public value objects belong in the dedicated adapter namespace
-`NeuronAI\Chat\Messages\Stream\Adapters\Events`:
+`Events/` holds the portable value objects: `StepStartedStreamEvent`, `StepFinishedStreamEvent`, `ActivityStreamEvent` (a replaceable progress snapshot) and `CustomStreamEvent` (a named escape hatch with a JSON-serializable value). They are stream output, not workflow routing events, and contain no protocol field names; each adapter translates them (`STEP_STARTED` / `STEP_FINISHED` / `ACTIVITY_SNAPSHOT` / `CUSTOM` on AG-UI, transient `data-*` parts on Vercel).
 
-- `StreamEventInterface` — marker for portable, intermediate UI events;
-- `StepStartedStreamEvent` — a named operation began;
-- `StepFinishedStreamEvent` — a named operation completed;
-- `ActivityStreamEvent` — a replaceable progress/activity snapshot;
-- `CustomStreamEvent` — a named escape hatch with a JSON-serializable value.
-
-These objects are stream output, not workflow routing events. A generator node
-may `yield` them and must still `return` its normal `Workflow\Events\Event` for
-graph traversal.
-
-Keeping them under `Adapters` makes their ownership explicit: they are the
-portable input contract adapters know how to encode, not provider stream chunks
-or workflow routing events. The optional mapping-capability interface remains in
-the parent `Adapters` namespace because it describes adapter behavior rather
-than an event value.
-
-### Developer mapping API
-
-`CustomizableStreamAdapterInterface` adds mapping without changing
-`StreamAdapterInterface`, so mapping remains an optional capability. Both built-in
-adapters implement it and share the exact-class registry and resolution behavior.
-
-The developer API is:
+`CustomizableStreamAdapterInterface::mapEvent()` (implemented once in `MapsStreamEvents`, used by both built-in adapters) lets a developer map their own domain events without touching the adapter:
 
 ```php
 $adapter->mapEvent(
     IndexingProgress::class,
-    static fn (IndexingProgress $event): ActivityStreamEvent =>
-        new ActivityStreamEvent(
-            id: $event->jobId,
-            type: 'indexing',
-            data: ['processed' => $event->processed, 'total' => $event->total],
-        ),
+    static fn (IndexingProgress $event): ?ActivityStreamEvent => new ActivityStreamEvent(
+        id: $event->jobId,
+        type: 'indexing',
+        data: ['processed' => $event->processed, 'total' => $event->total],
+    ),
 );
 ```
 
-Mapping rules:
+Resolution order: a yielded `StreamEventInterface` is encoded directly; then an **exact-class** mapping (no inheritance or first-match rules, so behavior stays predictable); then built-in native chunk conversion; anything else is ignored. A mapper returning `null` suppresses the event, and the implementation distinguishes "no mapping" from "mapped to null" so suppression never falls through to chunk handling. Mappers return value objects, never SSE strings or protocol arrays: the adapter is the single owner of wire format, escaping and framing. A `StreamEventInterface` the adapter cannot encode fails with an expressive exception rather than being dropped silently.
 
-1. A yielded `StreamEventInterface` is encoded directly.
-2. An exact-class developer mapping is resolved next. Do not use inheritance or
-   first-match rules; exact classes make behavior predictable.
-3. Existing native chunk conversion runs next.
-4. Any remaining object is ignored, preserving current behavior.
+## Protocol invariants
 
-A mapper returns `StreamEventInterface|null`. `null` means the explicitly mapped
-event is suppressed. Internally, mapping resolution must distinguish "no mapping"
-from "a mapping returned null" so suppression cannot fall through to built-in
-chunk handling.
+- **AG-UI**: `RUN_STARTED` is the first frame, `RUN_FINISHED` or `RUN_ERROR` the last; a text or reasoning lifecycle closes before an incompatible one begins; step, activity and custom events are run-level and never create, close or reuse text message state; the configured thread and run IDs are preserved on run framing.
+- **Vercel**: `start` is emitted exactly once, lazily, right before the first message-bearing native chunk, so a portable event may legitimately be the first yielded item; portable conversions are transient data never appended to the persisted assistant message; success ends with `finish` then `[DONE]`, failure with `error` then `[DONE]`.
 
-Mapper callbacks never return SSE strings, JSON, or protocol-specific arrays.
-The adapter remains the single owner of wire format, escaping, framing, and
-protocol evolution. If an object implements `StreamEventInterface` but the
-adapter cannot encode its concrete type, fail with an expressive exception
-instead of silently dropping a developer-declared portable event.
+## Durability
 
-### Protocol conversions
+Yielded items are live, ephemeral output: they are not stored in workflow persistence and are not replayed when a completed step is restored. Only the generator's returned routing event is durable. Never promise that a reconnecting client sees past progress events, and never make correctness depend on receiving one.
 
-| Portable event | AG-UI | Vercel AI SDK |
-|---|---|---|
-| `StepStartedStreamEvent` | `STEP_STARTED` | transient `data-workflow-step` with `status: started` |
-| `StepFinishedStreamEvent` | `STEP_FINISHED` | transient `data-workflow-step` with `status: finished` |
-| `ActivityStreamEvent` | `ACTIVITY_SNAPSHOT` | transient `data-workflow-activity` |
-| `CustomStreamEvent` | `CUSTOM` | transient `data-{name}` |
-
-Protocol-neutral value objects must not contain protocol field names. Each
-adapter translates semantic fields to the names required by its protocol.
-
-## Protocol lifecycle invariants
-
-### AG-UI
-
-- `RUN_STARTED` is the first frame; `RUN_FINISHED` or `RUN_ERROR` is the last frame.
-- `error(Throwable $error)` closes active text/reasoning lifecycles and emits
-  `RUN_ERROR` with the exception message and a string code when nonzero.
-  Subsequent adapter calls emit no frames.
-- A text or reasoning lifecycle must close before another incompatible lifecycle
-  begins.
-- Step, activity, and custom events are run-level events. They must not create,
-  close, or reuse text message state.
-- Preserve the configured thread ID and run ID on run framing.
-
-### Vercel AI SDK
-
-- A custom or portable event may be the first yielded item.
-- Never read `messageId` before confirming the object is a message-bearing native
-  chunk. The current lazy-start code does this and therefore cannot safely accept
-  a custom object before model output; the implementation must fix it.
-- Emit `start` exactly once, immediately before the first message-bearing native
-  chunk. Portable transient data can be emitted before it without inventing a
-  message.
-- Step, activity, and custom conversions are transient UI data and must not be
-  appended to the persisted assistant message.
-- Preserve the existing `finish` and `[DONE]` termination sequence on success.
-- On failure, emit `error` with `errorText`, then `[DONE]`. Subsequent adapter
-  calls emit no frames.
-
-Workflow calls `error()` automatically for failures caught during streamed
-execution or chunk transformation. The same failure frames reach pull consumers
-and the channel's `sendLine()` port. The channel still receives `failed()` and
-the original exception is rethrown to the caller.
-
-## Durability and replay
-
-Yielded stream items are live, ephemeral output. They are not stored in workflow
-persistence and are not replayed when a completed step is restored. Only the
-generator's returned routing event is the durable step result.
-
-This has two consequences:
-
-- do not claim that a client reconnect will receive past progress events;
-- do not make correctness depend on receiving a step/activity event.
-
-These events improve visibility and UX; workflow state and returned events remain
-the source of truth.
-
-## Memory integration
-
-Semantic memory is a consumer of this general feature, not part of the adapter
-layer. `RecallMemoryNode` and `StoreMemoryNode` yield named step events around
-recall and storage. Adapters never import memory node classes or use hardcoded
-memory branches.
-
-## Verification expectations
-
-Coverage must preserve:
-
-- direct portable event conversion in both built-in adapters;
-- exact-class mapping, mapped suppression, and mapper exceptions;
-- unknown unmapped objects remaining ignored;
-- a portable/custom event before the first Vercel native chunk;
-- Vercel emitting `start` once when the first native chunk later arrives;
-- AG-UI run and text/reasoning lifecycle ordering remaining valid;
-- mixed native chunks and portable events preserving their original order;
-- pull (`Agent::stream`) and push (`Workflow` channel) delivery receiving the
-  same converted lines from one Workflow-owned adapter path;
-- generator return events continuing to route the workflow and never being
-  emitted as UI progress.
+Semantic memory is a consumer of this feature, not part of it: `RecallMemoryNode` and `StoreMemoryNode` yield `memory.recall` / `memory.store` step events, and adapters never import memory classes.

--- a/src/Console/AGENTS.md
+++ b/src/Console/AGENTS.md
@@ -1,51 +1,10 @@
 # Console Module
 
-CLI commands for Neuron framework.
+CLI entry point (`php vendor/bin/neuron <command>`) for code generation and for running evaluations.
 
-## Structure
+## Design
 
-- `Command.php` - Abstract base: `run(array $args): int` plus print helpers (errors go to STDERR).
-- `NeuronCli.php` - Entry point. `commands()` is the single registry: command name => [description, factory closure]. The usage/help command list is generated from it.
-- `Make/MakeCommand.php` - One concrete class for all `make:*` commands, configured with (command name, resource type, stub file). To add a make command: add a stub in `Make/Stubs/` and a registry entry in `NeuronCli::commands()`.
-
-Run: `php vendor/bin/neuron <command>`
-
-## Make Commands (`Make/`)
-
-Code generation using stubs:
-
-| Command | Creates |
-|---------|---------|
-| `make:agent` | Agent class |
-| `make:tool` | Tool class |
-| `make:node` | Workflow Node |
-| `make:rag` | RAG class |
-| `make:workflow` | Workflow class |
-| `make:middleware` | Middleware class |
-| `make:event` | Event class |
-| `make:evaluators` | Evaluator class |
-
-```bash
-php vendor/bin/neuron make:agent MyAgent
-php vendor/bin/neuron make:tool MyTool
-```
-
-## Stubs (`Make/Stubs/`)
-
-Templates for code generation. Customize by publishing to application.
-
-## Evaluation (`Evaluation/`)
-
-`EvaluationCommand.php` - Run AI evaluations:
-
-```bash
-php vendor/bin/neuron evaluation path/to/evaluators
-php vendor/bin/neuron evaluation --verbose path/to/evaluators
-```
-
-**See**: `src/Evaluation/AGENTS.md` for evaluation framework details.
-
-## Dependencies
-
-- `Evaluation` module for evaluation command
-- File system access for make commands
+- `NeuronCli::commands()` is the single registry: command name => [description, factory closure]. The help output is generated from it, so there is nowhere else to register a command.
+- `Command` is the abstract base: `run(array $args): int` plus print helpers (errors go to STDERR).
+- `MakeCommand` is one concrete class for every `make:*` command, configured with (command name, resource type, stub file). Adding a generator means adding a stub in `Make/Stubs/` and one registry entry, never a new command class.
+- `EvaluationCommand` is a thin CLI over `src/Evaluation/`: flag parsing (`--verbose`, `--concurrency`, `--cache`, `--fresh`) lives here, the semantics live in the Evaluation module.

--- a/src/Evaluation/AGENTS.md
+++ b/src/Evaluation/AGENTS.md
@@ -1,303 +1,77 @@
 # Evaluation Module
 
-Dataset-driven AI evaluation with flexible assertions and output drivers, including
-first-class multi-turn conversation evaluation (tool calls, human-in-the-loop, simulated
-users).
+Dataset-driven evaluation of agents and workflows, including multi-turn conversations with tool calls, human-in-the-loop approvals and simulated users. It types against the general contracts (`AgentInterface`, `ChatHistoryInterface`, `InterruptRequest`, `ToolCall`), so anything built on the framework is evaluable.
 
-**Dependencies**: Agent, Chat, Workflow, Tools (typed against their general contracts:
-`AgentInterface`, `ChatHistoryInterface`, `InterruptRequest`, `ToolCall`).
+## Evaluator = template method
 
-## Running Evaluations
-
-```bash
-vendor/bin/neuron evaluation path/to/evaluators
-vendor/bin/neuron evaluation --verbose path/to/evaluators
-vendor/bin/neuron evaluation --concurrency=8 path/to/evaluators
-```
-
-`--concurrency=N` runs dataset items in N parallel child processes (requires
-`ext-pcntl` and `spatie/fork`; falls back to sequential otherwise). Each forked
-item gets its own copy of the evaluator, so per-item side effects (shared
-counters, appending to files) won't be visible across items. Evaluator outputs
-must be serializable to cross the process boundary; non-serializable outputs
-are replaced with a placeholder string in the results.
-
-## Run Output Caching (`--cache`)
-
-One sentence anchors the design: **the cache stores the output of `run()`, never the
-verdict — `evaluate()` always executes fresh.** Skipping an unchanged run is sound
-because a re-run of unchanged inputs yields no new information about your change (it
-samples the same distribution); re-evaluating stays free and lets you iterate on
-assertions, thresholds, and judges against frozen trajectories without re-running agents.
-
-```bash
-vendor/bin/neuron evaluation path/to/evaluators --cache    # skip unchanged runs
-vendor/bin/neuron evaluation path/to/evaluators --fresh    # re-run all, overwrite cache
-```
-
-The cache key (`Cache/CacheKey.php`) is a content fingerprint of what determines
-`run()`'s output:
-
-- the evaluator class and the **source of its `run()` method only** — editing
-  `evaluate()` does not invalidate recorded runs;
-- declared dependencies via `BaseEvaluator::cacheDependencies()` (override it to
-  return class-strings or file paths — your Agent class, prompt files). Undeclared
-  dependencies are invisible to invalidation: use `--fresh` after changing them;
-- the dataset item content (content-addressed — reordering a dataset invalidates
-  nothing, appended items simply miss);
-- the installed framework version.
-
-Entries live in `.neuron/cache/evaluation/` (override via `'cache' => ['path' => ...]`
-in `evaluation.php`), one file per key, written atomically so `--concurrency` children
-can't collide. Storage honors the same contract as the fork boundary: a non-serializable
-`run()` output is silently not cached. Cached items are flagged per result
-(`EvaluatorResult::isCachedRun()`, `cached_run` in JSON) and counted in the console
-summary — a skip is never confusable with a fresh run. Cache hits tell you nothing about
-provider drift: pair `--cache` in CI with a periodic `--fresh` run.
-
-`EvaluationCacheInterface` (`has`/`get`/`set`) is the storage seam;
-`FileEvaluationCache` is the built-in driver. To wipe the cache, delete the directory.
-
-## Architecture
-
-**Template Method Pattern**: `BaseEvaluator` workflow:
-1. `setUp()` - Initialize resources
-2. `getDataset()` - Provide test data (abstract)
-3. `run()` - Execute application logic (abstract)
-4. `evaluate()` - Assert results (abstract)
-
-## Core Components
-
-| Directory | Purpose |
-|-----------|---------|
-| `Contracts/` | Interfaces: `EvaluatorInterface`, `DatasetInterface`, `AssertionInterface`, `EvaluationOutputInterface` |
-| `BaseEvaluator.php` | Abstract base with assertion management |
-| `Dataset/` | `ArrayDataset`, `JsonDataset` |
-| `Assertions/` | Built-in: string (via `StringAssertion` base), JSON, similarity, distance; `Assertions/Trajectory/` for tool-call/HITL assertions; `Assertions/Judges/` for LLM judges |
-| `Conversation/` | `Conversation` (multi-turn runner), `UserSimulator`, `SimulatorOutput` |
-| `Trajectory/` | `Trajectory` — the recorded evaluation subject (view over chat messages) |
-| `Runner/` | `EvaluatorRunner`, `EvaluatorResult`, `EvaluationResults`, `EvaluatorReport`, `EvaluationReport` |
-| `Output/` | `ConsoleOutput`, `JsonOutput`, `OutputPipeline` |
-| `Config/` | Config loading and driver resolution |
-| `Discovery/` | Auto-discover evaluator classes |
-
-### Assertion type contract
-
-`AssertionInterface::evaluate(mixed $actual)` stays `mixed` (the polymorphic seam), but each
-assertion family enforces its concrete input type and **throws `InvalidArgumentException`** on
-a mismatch — a wrong input type is a coding error in the evaluator (surfaced as a per-item
-*error* by the runner), never a failed assertion about the agent. `StringAssertion` and
-`TrajectoryAssertion` are the shared bases; subclasses implement `evaluateString()` /
-`evaluateTrajectory()`.
-
-## Multi-Turn Conversation Evaluation
-
-One sentence anchors the design: **you run a Conversation; you evaluate its Trajectory**.
-
-### Trajectory — the recorded subject
-
-A read-only **view over the original typed chat messages** — no parallel data schema.
-Accessors answer evaluation questions directly from framework types:
+`BaseEvaluator` fixes the shape: `setUp()`, `getDataset()` (the items), `run($item)` (execute the application, return its output) and `evaluate($output, $item)` (assert). `EvaluatorDiscovery` finds evaluator classes in a directory and `EvaluatorRunner` executes them; `vendor/bin/neuron evaluation <path>` is the CLI.
 
 ```php
-$trajectory = Trajectory::fromChatHistory($agent->getChatHistory()); // or fromMessages()
-
-$trajectory->messages();          // Message[] — full fidelity
-$trajectory->toolCalls('refund'); // ToolCall[] — one entry per call (the "fold":
-                                  // pending snapshot + final outcome merged, final wins)
-$trajectory->lastToolCall();      // ?ToolCall
-$trajectory->finalAnswer();       // string ('' on a suspended tail)
-$trajectory->usage();             // Usage — aggregated provider-reported tokens
-$trajectory->toTranscript();      // canonical rendering (judges & simulator read this);
-                                  // attachments described, approval decisions annotated
-```
-
-`fromMessages()` is a public seam: any hand-rolled multi-turn loop can project its history
-and use the whole assertion/judge layer — the Conversation runner is sugar over it.
-Serialization reuses the chat-history storage format, so a Trajectory survives the parallel
-runner's fork boundary (messages carry `ToolCall` data). Gotchas:
-a call that never executed has no result — check `ToolCall::hasResult()` before calling
-`getResult()`; accessors return the LIVE call entries, which the approval flow annotates
-in place on resume — read values, don't hold objects across a resume.
-
-### Conversation — the runner
-
-```php
-public function run(array $item): mixed
+class RefundEvaluator extends BaseEvaluator
 {
-    return Conversation::make($this->makeAgent())
-        ->withTurns($item['turns'])              // scripted: list<string|UserMessage>
-        ->withApprovals(function (InterruptRequest $request, Trajectory $soFar): array {
-            $payload = [];
-            foreach ($request->getActions() as $action) {
-                if ($action->isPending()) {
-                    $payload[$action->id] = 'approve';   // or ['reject', $reason]
-                }
-            }
-            return $payload;
-        })
-        ->run();                                 // : Trajectory
-}
-```
+    protected AgentInterface $judge;
 
-- Each scripted turn is sent only after the previous one fully completed (including any
-  suspend → decide → resume cycle).
-- **Approval policy** (`withApprovals`): the callable plays the human whenever the agent
-  suspends, at any point. Typed against the generic `InterruptRequest` — narrow with
-  `instanceof` as needed. Fail-loud: a suspension with no policy throws
-  `EvaluationException`, and for `ApprovalRequest`s the returned payload must cover every
-  pending action id (an incomplete set would re-suspend and loop the runner).
-- Simulated path: `->withUser($simulator, maxTurns: 10)` instead of `withTurns()` (mutually
-  exclusive). `maxTurns` is required; hitting the cap ends the conversation *normally* —
-  whether unfinished is a failure is the assertions' judgment.
-
-### UserSimulator — goal-driven conversations
-
-An `Agent` subclass that plays the user and declares its own stop:
-
-```php
-$simulator = UserSimulator::make()
-    ->withPersona('An impatient customer')
-    ->withGoal('Get a refund for order 123');
-$simulator->setAiProvider($provider);   // returns AgentInterface — keep it off the chain
-```
-
-Each step is stateless (self-contained prompt: persona + goal + transcript; own history
-flushed per call). The simulator never answers suspensions — the user and the approver are
-different humans; approvals stay with the policy.
-
-### Trajectory assertions
-
-```php
-$this->assert(new ToolWasCalled('refund_order', ['order_id' => '123']), $trajectory);
-$this->assert(new ToolWasNotCalled('delete_account'), $trajectory);
-$this->assert(new TrajectoryMatches(['search', 'refund_order'], Mode::Subset), $trajectory);
-$this->assert(new ToolWasApproved('send_email'), $trajectory);
-$this->assert(new ToolWasRejected('refund_order'), $trajectory);
-```
-
-`ToolWasCalled` takes an optional argument constraint (array = subset match, strict
-equality per listed key; or `fn(array $inputs): bool`). `TrajectoryMatches` is names-only,
-with `Mode::Strict` (exact sequence), `Unordered` (same multiset), `Subset` (in-order
-subsequence, extras allowed), `Superset` (no call outside the allowed set). Final-answer
-assertions deliberately don't exist: the string catalog and judges apply to
-`$trajectory->finalAnswer()`.
-
-### Transcript-aware judges
-
-`AgentJudge` (and all prebuilt judges) accept `string|Trajectory` — a Trajectory is rendered
-into the prompt via the protected `renderTranscript()` seam (default `toTranscript()`).
-`TaskCompletionJudge` is the conversation-level judge: goal + full trajectory → did the
-assistant accomplish it.
-
-```php
-$this->assert(new TaskCompletionJudge($this->judge, goal: $item['goal']), $trajectory);
-```
-
-## Creating Evaluators
-
-```php
-class MyEvaluator extends BaseEvaluator
-{
-    public function getDataset(): DatasetInterface {
-        return new ArrayDataset([...]);
-    }
-
-    public function run(array $datasetItem): mixed {
-        // Your application logic
-        return $result;
-    }
-
-    public function evaluate(mixed $output, array $datasetItem): void {
-        $this->assert(new StringContains('expected'), $output);
-    }
-}
-```
-
-## Named Scores & Per-Metric Aggregation
-
-Every `assert()` records a `Score` (`label`, `value`, `passed`). The label defaults to the
-assertion's `getName()` and can be overridden to aggregate under a shared metric name:
-
-```php
-$this->assert(new TaskCompletionJudge($this->judge, goal: $item['goal']), $trajectory, 'task_completion');
-```
-
-`EvaluationResults::getScoresByLabel()` groups the records;
-`getScoreStatisticsByLabel()` returns per-metric `{average, min, max, count}` across the
-dataset (rendered by `ConsoleOutput`, and emitted by `JsonOutput` as the `metrics` block
-plus a per-result `scores` list). The flat float views (`EvaluatorResult::getAssertionScores()`,
-`EvaluationResults::getAllAssertionScores()` and the result collection avg/min/max) are derived from
-the same records — the result collection is the single home for statistics.
-
-## Evaluator Attribution
-
-The CLI passes one `EvaluationReport` to the output pipeline. It owns the exact UTC start and finish instants for the complete run and retains an ordered `EvaluatorReport` for each discovered evaluator. Each evaluator report owns its evaluator class, optional Agent/Workflow namespace, exact UTC start and finish instants, any error raised before item execution, and its `EvaluationResults`. Suite and evaluator durations are derived from their timestamps; item execution averages remain derived from individual results.
-
-Empty and errored evaluators therefore remain visible. Every `EvaluatorResult` also carries the producing evaluator class (`getEvaluatorClass()` / `getShortEvaluatorClass()`) so flat result exports remain attributable. Item indexes restart at zero for each evaluator.
-
-## Output Configuration
-
-Create `evaluation.php` in project root. Each `output` entry is either a
-class string of a zero-argument driver, or a fully-constructed driver instance.
-Drivers that need constructor arguments (dependencies, options) **must** be
-supplied as concrete instances - this lets the host framework resolve them
-through its DI container.
-
-```php
-use NeuronAI\Evaluation\Output\ConsoleOutput;
-use NeuronAI\Evaluation\Output\JsonOutput;
-
-return [
-    'output' => [
-        // Zero-argument driver, resolved as `new ConsoleOutput()`
-        ConsoleOutput::class,
-
-        // Constructed instance (e.g. to pass a path)
-        new JsonOutput('results.json'),
-    ],
-];
-```
-
-## Custom Output Drivers
-
-Implement `EvaluationOutputInterface`. Because drivers are registered as
-instances, dependencies can be injected through the constructor:
-
-```php
-class DatabaseOutput implements EvaluationOutputInterface
-{
-    public function __construct(
-        private readonly \PDO $pdo
-    ) {
-    }
-
-    public function output(EvaluationReport $report): void
+    public function setUp(): void
     {
-        // Store in database
+        $this->judge = JudgeAgent::make();
+    }
+
+    public function getDataset(): DatasetInterface
+    {
+        return new JsonDataset(__DIR__.'/refunds.json');
+    }
+
+    public function run(array $item): mixed
+    {
+        return Conversation::make(RefundAgent::make())
+            ->withTurns($item['turns'])
+            ->withApprovals(function (ApprovalRequest $request, Trajectory $soFar): array {
+                $decisions = [];
+                foreach ($request->getActions() as $action) {
+                    $decisions[$action->id] = 'approve';
+                }
+                return $decisions;
+            })
+            ->run();
+    }
+
+    public function evaluate(mixed $trajectory, array $item): void
+    {
+        $this->assert(new ToolWasCalled('refund_order', ['order_id' => $item['order_id']]), $trajectory);
+        $this->assert(new TaskCompletionJudge($this->judge, goal: $item['goal']), $trajectory, 'task_completion');
     }
 }
 ```
 
-Register the constructed instance in config:
+### Assertions and scores
 
-```php
-return [
-    'output' => [
-        new DatabaseOutput($container->get(\PDO::class)),
-    ],
-];
-```
+`AssertionInterface::evaluate(mixed $actual)` is the polymorphic seam, but each family (`StringAssertion`, `TrajectoryAssertion`, judges) enforces its concrete input and **throws `InvalidArgumentException`** on a mismatch: a wrong input type is a coding error in the evaluator, reported by the runner as a per-item *error*, never as a failed assertion about the agent.
 
-## Directory Setup
+Every `assert()` records a `Score` (`label`, `value`, `passed`). The label defaults to the assertion name and can be overridden (third argument) to aggregate several assertions under one metric. `EvaluationResults` is the single home for statistics: per-label groups and `{average, min, max, count}` are derived there and rendered by `ConsoleOutput` / `JsonOutput`. `EvaluationReport` wraps the whole run (UTC start/finish instants, one `EvaluatorReport` per discovered evaluator with its class, pre-execution error and results), so empty and errored evaluators stay visible.
 
-```json
-// composer.json
-{
-    "autoload-dev": {
-        "psr-4": {
-            "App\\Evaluators\\": "evaluators/"
-        }
-    }
-}
-```
+## Multi-turn: you run a Conversation, you evaluate its Trajectory
+
+`Trajectory` is a read-only **view over the original typed chat messages**, not a parallel data schema: `toolCalls()`, `lastToolCall()`, `finalAnswer()`, `usage()` and `toTranscript()` (the canonical rendering that judges and the simulator read) answer evaluation questions directly from framework types. `fromMessages()` / `fromChatHistory()` are public seams, so any hand-rolled loop can project its history and reuse the assertion layer; the `Conversation` runner is sugar over them. A call that never executed has no result: check `ToolCall::hasResult()` first. Accessors return the live call entries, which the approval flow annotates in place on resume, so read values rather than holding objects across a resume.
+
+`Conversation` sends each scripted turn only after the previous one fully completed, suspend → decide → resume cycles included:
+
+- `withApprovals(callable)` plays the human whenever the agent suspends, receiving the interrupt request and the trajectory so far. It is invoked for every suspension with the generic `InterruptRequest`, so type the callable against `ApprovalRequest` only when tool approval is the sole way the agent pauses. Fail-loud by design: a suspension with no policy throws `EvaluationException`, and an `ApprovalRequest` payload must cover every pending action id, otherwise the runner would re-suspend and loop.
+- `withUser(UserSimulator, maxTurns)` replaces scripted turns with a goal-driven simulated user (mutually exclusive with `withTurns()`). `maxTurns` is required; hitting it ends the conversation *normally*, and whether that is a failure is the assertions' judgment.
+
+`UserSimulator` is an `Agent` subclass with a persona and a goal that declares its own stop. Each step is stateless (persona + goal + transcript, own history flushed per call), and it never answers suspensions: the user and the approver are different humans, so approvals stay with the policy.
+
+Trajectory assertions: `ToolWasCalled` (optional argument constraint: subset array or predicate), `ToolWasNotCalled`, `TrajectoryMatches` (names only, with `Mode::Strict` / `Unordered` / `Subset` / `Superset`), `ToolWasApproved`, `ToolWasRejected`. There are deliberately no final-answer assertions: the string assertions and judges apply to `$trajectory->finalAnswer()`, and every judge accepts `string|Trajectory` (`TaskCompletionJudge` is the conversation-level one: goal + full trajectory).
+
+## Run output caching
+
+**The cache stores the output of `run()`, never the verdict; `evaluate()` always executes fresh.** Skipping an unchanged run yields no new information about your change (it samples the same distribution), while re-evaluating stays free and lets you iterate on assertions, thresholds and judges against frozen trajectories.
+
+The key (`Cache/CacheKey`) is a content fingerprint of what determines `run()`'s output: the evaluator class and the source of its `run()` method only, the declared `cacheDependencies()` (class-strings or file paths: your Agent class, prompt files), the dataset item content (content-addressed, so reordering invalidates nothing) and the framework version. Undeclared dependencies are invisible to invalidation; `--fresh` re-runs everything. Cached items are flagged per result and counted in the summary, so a skip is never confusable with a fresh run. Cache hits say nothing about provider drift: pair `--cache` in CI with a periodic `--fresh`. `EvaluationCacheInterface` is the storage seam and `FileEvaluationCache` the built-in driver (`.neuron/cache/evaluation/`, atomic writes so concurrent children cannot collide).
+
+## Concurrency
+
+`--concurrency=N` forks dataset items into N child processes (`ext-pcntl` + `spatie/fork`, sequential fallback). Each child gets its own evaluator copy, so per-item side effects are invisible across items, and `run()` outputs must be serializable to cross the boundary (non-serializable outputs become a placeholder and are not cached; `Trajectory` serializes through the chat-history format).
+
+## Output drivers
+
+`evaluation.php` in the project root lists `output` drivers: a class string for a zero-argument driver, or a constructed instance. Drivers with dependencies **must** be instances, which lets the host framework resolve them through its DI container; a custom driver implements `EvaluationOutputInterface::output(EvaluationReport $report)`.

--- a/src/HttpClient/AGENTS.md
+++ b/src/HttpClient/AGENTS.md
@@ -1,108 +1,23 @@
 # HttpClient Module
 
-Framework-agnostic HTTP abstraction for AI providers, vector stores, toolkits, and MCP transports.
-`HttpClientInterface` is the swappability seam: any implementation can be injected anywhere the
-framework talks HTTP. There is no PSR-18 layer underneath — PSR-18 cannot express the streaming
-contract (`stream()` must deliver bytes as they arrive), so implementations adapt concrete
-clients directly.
+Framework-agnostic HTTP abstraction used by providers, vector stores, toolkits and MCP transports. `HttpClientInterface` is the swappability seam: any implementation can be injected anywhere the framework talks HTTP, through the `HasHttpClient` trait. ext-curl is the only dependency.
 
-## Interface
+## Design decisions
 
-```php
-interface HttpClientInterface {
-    public function request(HttpRequest $request): HttpResponse;
-    public function stream(HttpRequest $request): StreamInterface;
-    public function withBaseUri(string $baseUri): HttpClientInterface;
-    public function withHeaders(array $headers): HttpClientInterface;
-    public function withTimeout(float $timeout): HttpClientInterface;
-}
-```
-
-Both `request()` and `stream()` throw `HttpException` on failure: with the `HttpResponse`
-attached for status >= 400 (checked at header arrival on `stream()`), without one for
-network errors.
-
-## Implementations
-
-| Class | Mode | Dependency |
-|-------|------|------------|
-| `CurlHttpClient` | Sync | ext-curl only — **the default everywhere** |
-| `GuzzleHttpClient` | Sync | guzzlehttp/guzzle (require-dev + suggest) — opt-in, e.g. for HandlerStack middleware |
-| `AmpHttpClient` | Async | amphp/http-client (require-dev) |
-
-`CurlHttpClient` drives `stream()` through a curl multi handle (`CurlStream`), so SSE chunks
-surface incrementally — live streaming is guaranteed, not client-dependent. It always suppresses
-`Expect: 100-continue` (some gateways, e.g. Google Vertex, reject it). The `curlOptions`
-constructor argument is the raw `CURLOPT_*` escape hatch (proxies, custom CA bundles, ...) and
-wins over the built-in defaults.
-
-All three send `User-Agent: neuron-ai/4.x` (`HttpClientInterface::USER_AGENT`) unless
-`withHeaders()` or the request supplies its own.
-
-### Request/response hooks
-
-`CurlHttpClient` offers taps — deliberately not middleware:
+- **No PSR-18 underneath.** PSR-18 cannot express the streaming contract (`stream()` must deliver bytes as they arrive), so implementations adapt concrete clients directly. `StreamInterface` is pull-based (`eof()`, `read()`, `readLine()`, `close()`), which is exactly what SSE parsing needs.
+- **`CurlHttpClient` is the default everywhere** because it needs ext-curl only. It drives `stream()` through a curl multi handle (`CurlStream`) so SSE chunks surface incrementally: live streaming is guaranteed by the framework, not dependent on the client the user picked. `GuzzleHttpClient` (HandlerStack middleware) and `AmpHttpClient` (async) are opt-in adapters. The `curlOptions` constructor argument is the raw `CURLOPT_*` escape hatch (proxies, CA bundles) and wins over the built-in defaults.
+- **Hooks are taps, not middleware.** `onRequest` hooks run in registration order and may return a modified request (dynamic auth, signing, logging); `onResponse` hooks are observation-only and also fire for error responses before the exception is thrown. There is intentionally no retry, caching or short-circuit power here: wrap the client behind the interface, or inject Guzzle with a HandlerStack, for that.
 
 ```php
 $client = (new CurlHttpClient())
-    ->onRequest(fn (HttpRequest $r): HttpRequest => $r->withHeaders(['Authorization' => 'Bearer '.$token()]))
-    ->onResponse(fn (HttpResponse $res, HttpRequest $req) => $logger->debug("{$req->uri} → {$res->statusCode}"));
+    ->onRequest(fn (HttpRequest $request): HttpRequest => $request->withHeaders(['Authorization' => 'Bearer '.$token()]))
+    ->onResponse(fn (HttpResponse $response, HttpRequest $request) => $logger->debug("{$request->uri} → {$response->statusCode}"));
 ```
 
-`onRequest` hooks run in registration order and may return a modified request (dynamic auth,
-signing, logging). `onResponse` hooks are observation-only and also fire for error responses
-before the `HttpException` is thrown; on `stream()` they receive the response with an empty
-body (the body is a live stream), except on error where it is drained. There is intentionally
-no retry/caching/short-circuit power here — wrap the client behind `HttpClientInterface` (or
-inject `GuzzleHttpClient` with a HandlerStack) for that.
-
-## Request/Response
-
-| Class | Purpose |
-|-------|---------|
-| `HttpRequest` | Request value object (method, uri, headers, body) with `::get()`/`::post()`/... factories |
-| `HttpResponse` | Response container (statusCode, body, headers) with `json()` and case-insensitive `header()` helpers |
-| `HttpMethod` | Enum: GET, POST, PUT, DELETE, PATCH |
-
-Array bodies are JSON-encoded; an array body containing resources (or `['contents' => ...]`
-parts) is sent as multipart, with upload filenames derived from the underlying file so APIs
-that infer format from the extension keep working. String bodies pass through raw.
-
-## Streaming
-
-`StreamInterface` for SSE/streaming responses (pull-based: `eof()`, `read()`, `readLine()`,
-`close()`):
-
-```php
-$stream = $client->stream($request);
-while (!$stream->eof()) {
-    $line = $stream->readLine();
-}
-```
-
-## Dependency Injection
-
-Use `HasHttpClient` trait:
-
-```php
-class MyProvider {
-    use HasHttpClient;
-
-    public function __construct() {
-        $this->setHttpClient(new CurlHttpClient());
-    }
-}
-```
+- **Errors are exceptions.** Both `request()` and `stream()` throw `HttpException`: with the `HttpResponse` attached for status >= 400 (checked at header arrival on `stream()`), without one for network errors.
+- **Body encoding is inferred from shape.** An `HttpRequest` array body is JSON-encoded; an array body containing resources (or `['contents' => ...]` parts) is sent as multipart with filenames derived from the underlying file, so APIs that infer format from the extension keep working. String bodies pass through raw.
+- Every client sends `User-Agent: neuron-ai/4.x` (`HttpClientInterface::USER_AGENT`) unless the caller supplies its own, and curl always suppresses `Expect: 100-continue` because some gateways (Google Vertex) reject it.
 
 ## Testing
 
-`tests/HttpClient/CurlHttpClientTest.php` and `AmpHttpClientTest.php` boot PHP's built-in server
-(`BootsFixtureServer` trait on `tests/HttpClient/fixtures/server.php`) and exercise the real
-stack; the curl test includes the assertion that SSE chunks arrive incrementally. Provider
-tests fake HTTP in-process through `GuzzleHttpClient` + Guzzle's `MockHandler` — they test
-provider logic through the seam, which is implementation-agnostic, and keep the Guzzle adapter
-exercised.
-
-## Dependencies
-
-ext-curl. Self-contained otherwise.
+The curl and amp tests boot PHP's built-in server (`tests/HttpClient/fixtures/server.php`) and exercise the real stack, including the assertion that SSE chunks arrive incrementally. Provider tests fake HTTP in-process through `GuzzleHttpClient` + Guzzle's `MockHandler`: they test provider logic through the seam, which is implementation-agnostic, and keep the Guzzle adapter exercised.

--- a/src/MCP/AGENTS.md
+++ b/src/MCP/AGENTS.md
@@ -1,162 +1,23 @@
 # MCP Module
 
-Model Context Protocol connector for external tool integration. MCP is an open standard by Anthropic to connect agents to external services.
+Model Context Protocol connector. An MCP server's tools become ordinary Neuron tools, so the agent loop, the approval gate and observability treat them exactly like local ones; nothing MCP-specific leaks past `ToolInterface`.
 
-**Dependencies**: `src/HttpClient/AGENTS.md`
+## How it fits together
 
-## Core
-
-| File | Purpose |
-|------|---------|
-| `McpConnector.php` | Establishes connection, discovers tools |
-| `McpClient.php` | Calls tools on MCP server |
-| `McpTransportInterface.php` | Transport contract |
-| `McpException.php` | Module exception |
-
-## Transports
-
-| Class | Protocol | Use Case |
-|-------|----------|----------|
-| `StdioTransport` | Standard I/O | Local MCP processes |
-| `SseHttpTransport` | Server-Sent Events | Remote servers with SSE |
-| `StreamableHttpTransport` | HTTP streaming | Standard HTTP MCP |
-
-## Usage with Agent Extension Pattern
-
-Connect MCP tools in your custom agent class:
+- `McpConnector` is the developer-facing entry point. `tools()` lists the server's tools, applies the `only()` / `exclude()` filters, and wraps each one in an `McpTool`: a `Tool` subclass whose `__invoke()` forwards the call back through the connector. Its input schema is translated into the regular `ToolProperty` / `ArrayProperty` / `ObjectProperty` definitions.
+- `McpClient` speaks JSON-RPC over an `McpTransportInterface`, selected from the config: `command` → `StdioTransport` (local process), `url` → `StreamableHttpTransport`, or `SseHttpTransport` when `async` is true; a custom `transport` instance can be passed instead. HTTP transports accept an optional `HttpClientInterface` (default `CurlHttpClient`).
+- The connector serializes to its config and filters only; the client, transport and HTTP client are dropped and rebuilt lazily on first use after unserialize.
 
 ```php
-use NeuronAI\Agent;
-use NeuronAI\MCP\McpConnector;
-use NeuronAI\Providers\AIProviderInterface;
-use NeuronAI\Providers\Anthropic\Anthropic;
-
-class MyAgent extends Agent
-{
-    protected function provider(): AIProviderInterface
-    {
-        return new Anthropic(
-            key: env('ANTHROPIC_API_KEY'),
-            model: 'claude-sonnet-4-6',
-        );
-    }
-
-    public function instructions(): string
-    {
-        return 'You are a helpful assistant with access to external tools.';
-    }
-
-    protected function tools(): array
-    {
-        return [
-            // Local MCP server via stdio
-            ...McpConnector::make([
-                'command' => 'php',
-                'args' => ['/path/to/mcp_server.php'],
-            ])->tools(),
-        ];
-    }
-}
-```
-
-### Remote MCP Server
-
-```php
-use NeuronAI\HttpClient\Guzzle\GuzzleHttpClient;use NeuronAI\MCP\McpConnector;
-
 protected function tools(): array
 {
     return [
-        // HTTP transport
-        ...McpConnector::make([
-            'url' => 'https://mcp.example.com',
-            'token' => env('MCP_BEARER_TOKEN'),
-            'timeout' => 30,
-        ], httpClient: new GuzzleHttpClient())->tools(),
+        ...McpConnector::make(['command' => 'php', 'args' => ['/path/to/mcp_server.php']])->tools(),
+        ...McpConnector::make(['url' => 'https://mcp.example.com', 'token' => env('MCP_BEARER_TOKEN')])
+            ->only(['search', 'read'])
+            ->tools(),
     ];
 }
 ```
 
-The optional `httpClient` argument accepts any `HttpClientInterface` implementation. If omitted,
-MCP HTTP transports use `CurlHttpClient`.
-
-### SSE Transport (Async)
-
-```php
-protected function tools(): array
-{
-    return [
-        ...McpConnector::make([
-            'url' => 'https://mcp.example.com',
-            'token' => env('MCP_BEARER_TOKEN'),
-            'async' => true, // Enables SSE transport
-        ])->tools(),
-    ];
-}
-```
-
-## Filtering Tools
-
-Control which tools are exposed from the MCP server:
-
-```php
-protected function tools(): array
-{
-    return [
-        // EXCLUDE: discard certain tools
-        ...McpConnector::make([
-            'url' => 'https://mcp.example.com',
-        ])->exclude([
-            'dangerous_tool',
-            'admin_tool',
-        ])->tools(),
-
-        // ONLY: select specific tools
-        ...McpConnector::make([
-            'url' => 'https://mcp.example.com',
-        ])->only([
-            'search_tool',
-            'read_tool',
-        ])->tools(),
-    };
-}
-```
-
-## Multiple MCP Servers
-
-```php
-protected function tools(): array
-{
-    return [
-        // Database tools
-        ...McpConnector::make([
-            'command' => 'mcp-server-postgres',
-            'args' => ['postgres://localhost/mydb'],
-        ])->tools(),
-
-        // File system tools
-        ...McpConnector::make([
-            'command' => 'mcp-server-filesystem',
-            'args' => ['/home/user/documents'],
-        ])->tools(),
-    ];
-}
-```
-
-## MCP Server Directories
-
-Find pre-built MCP servers:
-- [MCP Official GitHub](https://github.com/modelcontextprotocol/servers)
-- [MCP-GET Registry](https://mcp-get.com/)
-
-## How It Works
-
-1. `McpConnector` establishes connection using configured transport
-2. Neuron discovers tools exposed by the MCP server
-3. Tools are converted to `ProviderTool` instances
-4. When agent calls a tool, Neuron sends request to MCP server
-5. Result is returned to the LLM to continue the task
-
-## Dependencies
-
-- `HttpClient` for HTTP transports
+`FakeMcpTransport` (`src/Testing/`) implements the transport contract for tests: queue JSON-RPC responses, then assert what was sent.

--- a/src/Observability/AGENTS.md
+++ b/src/Observability/AGENTS.md
@@ -1,96 +1,28 @@
 # Observability Module
 
-PSR-14 event dispatching for monitoring. Each Workflow instance owns its own
-dispatcher — there is no global state, so concurrent workflows (long-running
-workers, async branches, nested agents) are isolated by construction.
+PSR-14 event dispatching for monitoring what a workflow does. Each `Workflow` instance owns its own dispatcher: there is no global state, so concurrent workflows (long-running workers, async branches, nested agents) are isolated by construction. The only dependency is `psr/event-dispatcher`.
 
-## Core
+## Model
 
-| File | Purpose |
-|------|---------|
-| `ObservabilityEvent.php` | Abstract base for all events. Carries `source` (the emitting component) and `branchId` (parallel branch, or null), stamped at dispatch time. `name()` returns the legacy string name ('inference-start'), derived from the class name unless overridden. |
-| `ListenerRegistry.php` | PSR-14 `ListenerProviderInterface`. Class-keyed listeners, instanceof matching — subscribing to `ObservabilityEvent::class` receives every event. |
-| `WorkflowEventDispatcher.php` | PSR-14 `EventDispatcherInterface`. Runs the workflow's listeners, then forwards to an optional external dispatcher. |
-| `ObserverInterface.php` | **Deprecated** legacy observer contract: `onEvent(name, source, data, branchId)`. Still works via `ObserverAdapter`; removed in the next major. |
-| `ObserverAdapter.php` | **Deprecated** — wraps an `ObserverInterface` as a PSR-14 listener on `ObservabilityEvent`; removed together with it. |
-
-## Usage
+- `ObservabilityEvent` is the base of every framework event. The event class is the dispatch identity; `name()` derives a string name from it (`InferenceStart` → 'inference-start') for loggers and legacy observers, overridden only where it cannot be derived. `source` (the emitting component) and `branchId` (the parallel branch, or null) are stamped at dispatch time, not by the emitter.
+- `ListenerRegistry` matches listeners with `instanceof` semantics: subscribing to `ObservabilityEvent::class` receives everything, subscribing to a base class receives its subclasses.
+- `WorkflowEventDispatcher` runs the workflow's listeners, then forwards to an optional external PSR-14 dispatcher (`setEventDispatcher()`), which is how a host framework's event system receives every event with no glue code.
 
 ```php
-// PSR-style, class-keyed listeners
-$workflow->subscribe(InferenceStop::class, function (InferenceStop $event) {
-    // $event->source is the emitting node, $event->branchId the parallel branch (or null)
-});
-
-// Catch-all
-$workflow->subscribe(ObservabilityEvent::class, fn (ObservabilityEvent $e) => $log($e->name()));
-
-// Integrate with a host framework: forward every event to its PSR-14 dispatcher
-$workflow->setEventDispatcher($symfonyEventDispatcher);
-
-// DEPRECATED: legacy observers still work during the transition
-// (LogObserver, InspectorObserver, ...) but will be removed in the next major
-$workflow->observe(new LogObserver($logger));
-```
-
-Listeners are registered on the workflow **instance** and live as long as it
-does — they observe every run of that instance (including resume cycles on the
-same object).
-
-## Emitting Events (internal)
-
-The executor dispatches lifecycle events (`WorkflowStart`, `WorkflowNodeStart`,
-`MiddlewareStart`, `BranchStart`, `AgentError`, ...). A run that suspends for
-external input dispatches one `WorkflowInterrupted` carrying the complete
-`WorkflowState` and its active interrupt requests. It is a scheduled pause, not
-a failure, so listeners can route it to something other than error alerting.
-The terminal vocabulary:
-`WorkflowEnd` alone = completed; `WorkflowInterrupted` + `WorkflowEnd` = paused;
-`AgentError` + `WorkflowEnd` = failed. Nodes emit domain events through
-`Node::emit()`:
-
-```php
-// Inside a node — the event object IS the payload
-$this->emit(new ToolCalling($tool));
-```
-
-Agent memory nodes complement the generic node lifecycle with domain pairs:
-`MemoryRecalling` / `MemoryRecalled` and `MemoryStoring` / `MemoryStored`.
-Their start/completion timestamps delimit the actual memory boundary, while
-`MemoryRecalled` reports the result count. They intentionally carry no queries,
-messages, memory content, retrieval scope, or thread IDs. A failure emits the
-start event and the existing `AgentError`, but no successful completion event.
-
-`emit()` accepts any object (PSR-14 semantics). `ObservabilityEvent` instances are
-stamped with the emitting node as `source` and the current `branchId`. A node
-running without an executor has no dispatcher and emits nothing.
-
-To add a custom event, subclass `ObservabilityEvent` and subscribe to its class.
-
-## Built-in Listeners
-
-### LogListener
-
-PSR-3 logger integration as a PSR-14 listener. Logs every event's `name()` with
-per-event-class serialized context; override the protected `serialize*` methods
-to customize.
-
-```php
+$workflow->subscribe(InferenceStop::class, fn (InferenceStop $event) => $metrics->record($event->source, $event->branchId));
 $workflow->subscribe(ObservabilityEvent::class, new LogListener($psrLogger));
 ```
 
-### LogObserver (deprecated)
+Listeners are registered on the workflow instance and observe every run of it, resume cycles included.
 
-Legacy `ObserverInterface` variant of `LogListener` (a thin subclass), registered
-via the deprecated `observe()`. Use `LogListener` instead.
+## Emitting
 
-## Events (`Events/`)
+The executor dispatches the lifecycle (`WorkflowStart`, `WorkflowNodeStart`/`End`, `MiddlewareStart`/`End`, `BranchStart`/`End`, `AgentError`, `WorkflowEnd`). Nodes emit domain events through `Node::emit()`, where the event object *is* the payload; `emit()` accepts any object (PSR-14 semantics) and is a no-op when the node runs without an executor. A custom event is a subclass of `ObservabilityEvent` plus a subscription to its class.
 
-One class per lifecycle point. The class is the dispatch identity; `name()`
-provides the legacy string name for observers/loggers (overridden where it
-can't be derived from the class name, e.g. `AgentError` → 'error',
-`Retrieving` → 'rag-retrieving').
+The terminal vocabulary is deliberate. `WorkflowEnd` alone means completed. `WorkflowInterrupted` (carrying the full `WorkflowState` and its active interrupt requests) followed by `WorkflowEnd` means paused for external input: a scheduled pause, not a failure, so listeners can route it away from error alerting. `AgentError` followed by `WorkflowEnd` means failed.
 
-## Dependencies
+Memory events (`MemoryRecalling`/`MemoryRecalled`, `MemoryStoring`/`MemoryStored`) delimit the memory boundary and report counts only: no queries, recalled content, retrieval scope or thread IDs, so the default log context never leaks conversation data. A failing memory operation emits its start event and `AgentError`, never a completion event.
 
-`psr/event-dispatcher` only.
+## Deprecated path
+
+`ObserverInterface` (`onEvent(name, source, data, branchId)`) and `LogObserver` still work through `observe()`, which wraps them with `ObserverAdapter` as a listener on `ObservabilityEvent`. They exist only for the transition; new code uses `subscribe()` and `LogListener`.

--- a/src/Providers/AGENTS.md
+++ b/src/Providers/AGENTS.md
@@ -1,157 +1,31 @@
 # Providers Module
 
-AI provider abstractions. All providers implement `AIProviderInterface`.
+Adapters between Neuron's messaging layer and each AI vendor's API. Every provider implements `AIProviderInterface` (`chat()`, `stream()`, `structured()`, `setTools()`, `systemPrompt()`): it takes Neuron `Message`s and returns a `ProviderResponse` or a `Generator` of stream chunks, so the Agent never sees a vendor payload.
 
-**Dependencies**: `src/Chat/AGENTS.md`, `src/HttpClient/AGENTS.md`
+## Anatomy of a provider
 
-## Interface
+Each vendor directory holds cooperating pieces with one responsibility each:
 
-```php
-interface AIProviderInterface {
-    public function chat(array $messages): Message;
-    public function stream(array $messages): Generator;
-    public function setTools(array $tools): self;
-}
-```
+- the provider class owns the HTTP conversation: `HasHttpClient` for the injectable client, `SSEParser` plus a `BasicStreamState` subclass for streaming, `HandleWithTools` for the tool registry. `newToolCall()` validates the tool name the model asked for against that registry before a `ToolCall` is created;
+- a `MessageMapper` (`MessageMapperInterface`) translates Neuron messages, content blocks and tool call/result messages into the vendor format;
+- a `ToolMapper` (`ToolMapperInterface`) translates `Tool` definitions into the vendor's tool schema, when the API supports tools.
 
-## Provider Implementations
+Keep the split: mapping is pure data translation, tested in isolation from HTTP. OpenAI-compatible vendors (Deepseek, ZAI, Cohere, Grok, ...) extend `OpenAI` and its mappers instead of duplicating the protocol; `OpenAILike` / `OpenAILikeResponses` are the generic "any OpenAI-compatible endpoint" variants for the Chat Completions and Responses APIs, configured with a base URI.
 
-| Directory | Provider |
-|-----------|----------|
-| `Anthropic/` | Claude API |
-| `OpenAI/` | GPT models |
-| `Gemini/` | Google Gemini |
-| `Ollama/` | Local models |
-| `Mistral/` | Mistral AI |
-| `Deepseek/` | Deepseek |
-| `Cohere/` | Cohere |
-| `HuggingFace/` | Hugging Face |
-| `XAI/` | xAI Grok |
-| `ZAI/` | Zhipu AI |
-| `AWS/` | AWS Bedrock |
-| `ElevenLabs/` | ElevenLabs TTS |
+## Multimodal and failed tool results
 
-Each provider has:
-- `*Provider.php` - Main implementation
-- `*MessageMapper.php` - Converts `Message` → API format
-- `*ToolMapper.php` - Converts `Tool` → API format (if tools supported)
+A tool result is `string|ToolOutput`. Mappers detect multimodality on the **value** (`$tool->getResult() instanceof ToolOutput`), never on the tool type, and map the blocks natively where the API accepts them (Anthropic, Bedrock, Gemini, OpenAI Chat and Responses, Mistral) by reusing the mapper's existing block mapping; block types an API does not support fall out through the same null-filtering, and text-only APIs (Ollama) fall back to `ToolOutput::getText()`. An error output (`ToolOutput::error()`) sets the vendor's native error flag where one exists (`is_error` on Anthropic, `status: "error"` on Bedrock); elsewhere the feedback text itself carries the semantics.
 
-## Key Files
-
-| File | Purpose |
-|------|---------|
-| `AIProviderInterface.php` | Main contract |
-| `HandleWithTools.php` | Trait for tool management |
-| `MessageMapperInterface.php` | Message conversion contract |
-| `ToolMapperInterface.php` | Tool conversion contract |
-| `SSEParser.php` | Server-Sent Events parsing for streaming |
-| `OpenAILike.php` | Base for OpenAI-compatible APIs |
-| `OpenAILikeResponses.php` | Response handling for OpenAI-like APIs |
-| `BasicStreamState.php` | Stream state tracking |
-
-## Multimodal Tool Results
-
-A tool result is `string|ToolOutput` (see `src/Tools/AGENTS.md`). Each MessageMapper's
-tool-result mapping checks `$tool->getResult() instanceof ToolOutput` — detection is on
-the value, never the tool type — and maps the content blocks natively where the
-underlying API accepts them, reusing the mapper's existing block-mapping code:
-
-| Provider | Behavior with a `ToolOutput` result |
-|----------|-------------------------------------|
-| Anthropic | `tool_result.content` as native block array (`text`, `image`, `document`) |
-| AWS Bedrock | `toolResult.content` as native block array (`text`, `image`, `document`, `video`, `audio`) |
-| Gemini | `functionResponse.response.content` = `{parts: [...]}` (`text`, `inline_data`, `file_data`) |
-| OpenAI Chat Completions | `content` as block array (`text`, `image_url`). Inherited by Cohere, Deepseek, ZAI |
-| OpenAI Responses | `function_call_output.output` as block array (`input_text`, `input_image`, `input_file`) |
-| Mistral | `content` as block array (`text`, `image_url`, `document_url`, `input_audio`) |
-| Ollama | Text-only API — falls back to `ToolOutput::getText()` |
-
-Block types a provider's API doesn't support fall out through the mapper's existing
-null-filtering. Plain string results map exactly as before.
-
-An error output (`ToolOutput::error()`) additionally sets the provider's
-native error flag where one exists — `is_error: true` on Anthropic's `tool_result`,
-`status: "error"` on Bedrock's `toolResult`. The other providers have no such concept;
-the feedback text itself carries the error semantics.
-
-## Usage with Agent Extension Pattern
-
-Create a custom agent class extending `Agent`:
+## Wiring into an agent
 
 ```php
-use NeuronAI\Agent;
-use NeuronAI\Providers\AIProviderInterface;
-use NeuronAI\Providers\Anthropic\Anthropic;
-use NeuronAI\SystemPrompt;
-
 class MyAgent extends Agent
 {
     protected function provider(): AIProviderInterface
     {
-        return new Anthropic(
-            key: env('ANTHROPIC_API_KEY'),
-            model: 'claude-sonnet-4-6',
-        );
+        return new Anthropic(key: env('ANTHROPIC_API_KEY'), model: 'claude-sonnet-4-6');
     }
-
-    public function instructions(): string
-    {
-        return (string) new SystemPrompt(
-            background: ['You are a helpful AI assistant.'],
-            steps: ['Answer questions accurately and concisely.'],
-            output: ['Be friendly and professional.']
-        );
-    }
-}
-
-// Usage
-$response = MyAgent::make()->chat(new UserMessage('Hello!'))->getMessage();
-```
-
-### Alternative Providers
-
-```php
-// OpenAI
-use NeuronAI\Providers\OpenAI\OpenAI;
-
-protected function provider(): AIProviderInterface
-{
-    return new OpenAI(
-        key: env('OPENAI_API_KEY'),
-        model: 'gpt-4o',
-    );
-}
-
-// Gemini
-use NeuronAI\Providers\Gemini\Gemini;
-
-protected function provider(): AIProviderInterface
-{
-    return new Gemini(
-        key: env('GEMINI_API_KEY'),
-        model: 'gemini-2.0-flash',
-    );
-}
-
-// Ollama (local)
-use NeuronAI\Providers\Ollama\Ollama;
-
-protected function provider(): AIProviderInterface
-{
-    return new Ollama(
-        model: 'llama3.2',
-    );
 }
 ```
 
-## Adding New Provider
-
-1. Create `src/Providers/NewProvider/`
-2. Implement `NewProviderProvider.php` with `AIProviderInterface`
-3. Create `NewProviderMessageMapper.php` implementing `MessageMapperInterface`
-4. Create `NewProviderToolMapper.php` if tools supported
-5. Use `HasHttpClient` trait for HTTP injection
-
-## HTTP Client
-
-Providers use `HttpClientInterface` via `HasHttpClient` trait. Default is `CurlHttpClient` (ext-curl, dependency-free); inject `GuzzleHttpClient` for Guzzle middleware support.
+The default HTTP client is `CurlHttpClient`; inject `GuzzleHttpClient` through `setHttpClient()` when Guzzle middleware is needed (see `src/HttpClient/AGENTS.md`).

--- a/src/RAG/AGENTS.md
+++ b/src/RAG/AGENTS.md
@@ -1,315 +1,75 @@
 # RAG Module
 
-Retrieval Augmented Generation. Extends Agent with document search.
+Retrieval Augmented Generation. `RAG` extends `Agent`, so it inherits the whole Agent/Workflow machinery (thread identity, persistence, resume, memory, approvals) and only replaces the entry chain of the graph.
 
-**Dependencies**: `src/Agent/AGENTS.md`, `src/Chat/AGENTS.md`, `src/Providers/AGENTS.md`
+## The retrieval chain
 
-## Architecture
+`RAG::entryNodes()` swaps the Agent's `StartNode` for a retrieval pipeline whose last node produces the inference event:
 
-RAG extends Agent → inherits all Agent + Workflow capabilities (including
-`resume()`, thread identity, and the ignition record — see `src/Agent/AGENTS.md`).
-
-RAG overrides `entryNodes()`: the retrieval chain replaces the Agent's
-`StartNode` as the entry chain, and RAG's inference event is born at its end,
-in `InstructionsNode`:
-
-```
-AgentStartEvent → PreProcessNode → RetrievalNode → PostProcessNode → InstructionsNode → [RecallMemoryNode when requested] → inference
+```text
+AgentStartEvent → PreProcessNode → RetrievalNode → PostProcessNode → InstructionsNode → [RecallMemoryNode] → inference
 ```
 
-1. Extract and pre-process the user question (query expansion, rewriting).
-   The question is read from the start event, and nothing is written to chat
-   history before inference: `PreProcessNode` initializes `state->request`, whose
-   pending messages commit only after the provider call succeeds, as in the Agent,
-   so a failed turn never leaves a dangling user message on the thread.
-2. Retrieve relevant documents from the VectorStore. `QueryPreProcessedEvent`
-   is the injection channel for retrieval filters: middleware (in `before()`
-   on `RetrievalNode`) and preceding nodes call `addFilters(FilterExpression)`;
-   the node combines each mandatory scope at the root with AND and forwards the
-   resulting expression to the retrieval strategy. A scope may contain nested
-   AND/OR logic, but it can never relax another scope.
-   The event is born fresh every run, so a filter never leaks into the next run.
-3. Post-process (re-rank, filter)
-4. `InstructionsNode` enriches `state->request->instructions` with retrieved
-   documents, preserving earlier middleware changes. Messages and options stay in
-   the state request throughout retrieval; intermediate events carry only their
-   query, filters, and documents. Custom nodes can edit the state request directly.
-   When requested through `setMemoryUsage()`, routing passes through recall before
-   inference. Remember routing remains independent after the final response.
+- `PreProcessNode` reads the question from the start event, initializes `state->request` (the role `StartNode` plays in the Agent) and runs the pre-processors (query rewriting, expansion). Nothing is written to chat history before inference: pending messages commit only after the provider call succeeds, so a failed turn never leaves a dangling user message.
+- `RetrievalNode` asks the retrieval strategy. `QueryPreProcessedEvent` is the **injection channel for filters**: middleware (`before()` on `RetrievalNode`) and preceding nodes call `addFilters()`, the node ANDs every mandatory scope at the root and forwards the expression. A scope may contain nested AND/OR logic but can never relax another scope, and the event is born fresh every run, so a filter cannot leak into the next one.
+- `PostProcessNode` re-ranks or filters the documents.
+- `InstructionsNode` enriches `state->request->instructions` with the retrieved documents, preserving earlier middleware changes. Messages and options stay in the state request throughout; intermediate events carry only query, filters and documents.
 
-## Core Files
-
-| File | Purpose |
-|------|---------|
-| `RAG.php` | Main class, extends Agent |
-| `Document.php` | Document container with content, metadata, embedding |
-| `ResolveVectorStore.php` | Trait for vector store injection |
-| `ResolveEmbeddingProvider.php` | Trait for embeddings provider |
-| `ResolveRetrieval.php` | Trait for retrieval strategy |
-
-## Usage with RAG Extension Pattern
-
-Create a custom RAG class extending `RAG`:
+Collaborators come through lazy hooks with setter twins, like the Agent's provider: `embeddings()`, `vectorStore()`, `retrieval()`, `retrievalScope()`, `preProcessors()`, `postProcessors()`.
 
 ```php
-use NeuronAI\Providers\AIProviderInterface;
-use NeuronAI\Providers\Anthropic\Anthropic;
-use NeuronAI\RAG\Embeddings\EmbeddingsProviderInterface;
-use NeuronAI\RAG\Embeddings\OpenAIEmbeddingsProvider;
-use NeuronAI\RAG\RAG;
-use NeuronAI\RAG\VectorStore\FileVectorStore;
-use NeuronAI\RAG\VectorStore\VectorStoreInterface;
-
 class WorkoutTipsAgent extends RAG
 {
-    protected function provider(): AIProviderInterface
-    {
-        return new Anthropic(
-            key: env('ANTHROPIC_API_KEY'),
-            model: 'claude-sonnet-4-6',
-        );
-    }
+    protected function provider(): AIProviderInterface { /* ... */ }
 
     protected function embeddings(): EmbeddingsProviderInterface
     {
-        return new OpenAIEmbeddingsProvider(
-            key: env('OPENAI_API_KEY'),
-            model: 'text-embedding-3-small',
-        );
+        return new OpenAIEmbeddingsProvider(key: env('OPENAI_API_KEY'), model: 'text-embedding-3-small');
     }
 
     protected function vectorStore(): VectorStoreInterface
     {
-        return new FileVectorStore(
-            storage: storage_path('app/embeddings'),
-        );
+        return new FileVectorStore(directory: storage_path('app/embeddings'));
+    }
+
+    protected function retrievalScope(): ?FilterExpression
+    {
+        return Filter::where('tenant', $this->tenantId)->whereIn('status', ['published', 'reviewed']);
     }
 }
-
-// Usage
-$response = WorkoutTipsAgent::make()->chat(
-    new UserMessage('What are the best exercises for back pain?')
-);
 ```
 
-## Vector Stores (`VectorStore/`)
+`RetrievalInterface::retrieve(Message $query, ?FilterExpression $filters)` receives the per-run filters; a strategy must AND them with its own, never drop them. `SimilarityRetrieval` is the built-in strategy.
 
-`VectorStoreInterface` is filter-aware and stateless per call:
+## Vector stores are stateless per call
 
-```php
-$store->search(new SearchRequest(embedding: $vector, filters: $group, topK: 8));
-$store->delete(Filter::eq('sourceType', 'file'));
-```
-
-`SearchRequest` is an immutable per-call value (embedding, `?FilterExpression`,
-`?int topK` — null falls back to the store's constructor default). There is
-no mutable search state on a store: a filter set for one call cannot leak
-into the next.
+`VectorStoreInterface::search(SearchRequest)` takes an immutable per-call value (embedding, optional filters, optional `topK` falling back to the store's default). There is no mutable search state on a store, so a filter set for one call cannot leak into the next. `delete(FilterExpression)` uses the same filter model.
 
 ### The filter model (`VectorStore/Filter/`)
 
-A portable, backend-neutral expression tree compiled to each store's native
-syntax. This is **filtered similarity search**: metadata filters constrain
-vector similarity results. Reserve **hybrid search** for strategies that
-combine vector and lexical ranking.
+A portable, backend-neutral expression tree compiled to each store's native syntax by a compiler in `VectorStore/Compilers/` (internal wiring: no shared interface, not injectable; the file and memory stores evaluate the tree in PHP through `FilterEvaluator` instead). This is *filtered similarity search*; reserve "hybrid search" for strategies that combine vector and lexical ranking.
 
-- `Filter::eq/neq/in/gt/gte/lt/lte(field, value)` — low-level comparison
-  factories. `Filter::where(field, value)` starts an immutable fluent
-  `Criteria` with `where*` methods for the common path.
-  Values are scalars only (`null` throws: no portable missing-vs-null
-  semantics); range values normalize to `int|float` (string ranges are not
-  portable). Backed enums normalize to their value and `DateTimeInterface`
-  values normalize to epoch timestamps.
-- `FilterGroup::allOf(...)` / `anyOf(...)` — nested boolean expressions;
-  `and(...)` / `or(...)` remain short aliases. Same-operator groups flatten,
-  while mixed operators preserve their boundaries.
-- `FilterScope::merge(...)` — combines independently supplied mandatory
-  scopes with a root AND. Query expressiveness and scope safety are separate.
-- `Filter::containsAny/containsAll(field, values)` — portable filtering for
-  filterable `string[]` fields. Other array types remain backend-native.
-- `Filter::raw(StoreClass::class, $fragment)` — backend-native escape hatch,
-  tagged with its target store. The tagged store passes the fragment through
-  verbatim; every other store's compiler throws (fail-loud on store swap,
-  never silent misfiltering). Raw fragments must be trusted, developer-authored
-  syntax; never interpolate request values into them.
+- `Filter::eq/neq/in/gt/gte/lt/lte/containsAny/containsAll()` are the comparison leaves; `Filter::where()` starts an immutable fluent `Criteria` for the common path. Values are scalars only (`null` throws: there is no portable missing-vs-null semantics), ranges normalize to `int|float`, backed enums to their value, dates to epoch timestamps.
+- `FilterGroup::allOf()` / `anyOf()` nest boolean logic; `FilterScope::merge()` combines independently supplied mandatory scopes with a root AND. Query expressiveness and scope safety are separate concerns on purpose.
+- `Filter::raw(StoreClass::class, $fragment)` is the backend-native escape hatch, tagged with its target store: that store passes it through verbatim, every other compiler throws. Fail loud on a store swap, never misfilter silently. Raw fragments are trusted developer syntax; never interpolate request values into them.
+- Retrieval logs include fields, operators and boolean structure but omit comparison values and raw fragments, so authorization data does not leak into the default log context.
 
-Each backend has a compiler class in `VectorStore/Filter/Compilers/`
-(`QdrantFilterCompiler`, `MeilisearchFilterCompiler`, ...;
-`OpenSearchFilterCompiler` extends the Elasticsearch one). Compilers are
-internal wiring — no shared interface, not injectable. `FileVectorStore` and
-`MemoryVectorStore` share the PHP-side `FilterEvaluator` instead (raw filters
-throw there — nothing can execute them).
+### Document and schema
 
-Retrieval logs include the filter's fields, operators, and boolean structure,
-but omit comparison values and raw fragments so authorization data does not
-leak into the default log context.
+`Document` is the single processing object across loading, splitting, embedding, storage, retrieval and reranking. Embedding and score are nullable runtime values, so strict `null` checks say whether a stage produced them (`0.0` is a valid score).
 
-Backend caveats: Meilisearch filterable attributes and new MongoDB Atlas
-indexes are derived from `DocumentSchema`; existing indexes may require
-recreation. Weaviate keeps an opaque metadata copy and projects declared
-filter fields to native properties. Pinecone filter-based deletion works on
-pod-based indexes only.
-
-`VectorStoreInterface` implementations:
-
-| Class | Backend |
-|-------|---------|
-| `PineconeVectorStore` | Pinecone |
-| `ChromaVectorStore` | ChromaDB |
-| `QdrantVectorStore` | Qdrant |
-| `ElasticsearchVectorStore` | Elasticsearch |
-| `OpenSearchVectorStore` | OpenSearch |
-| `TypesenseVectorStore` | Typesense |
-| `MeilisearchVectorStore` | Meilisearch |
-| `MongoDBVectorStore` | MongoDB Atlas Vector Search |
-| `MariaDBVectorStore` | MariaDB vectors |
-| `WeaviateVectorStore` | Weaviate |
-| `FileVectorStore` | Local file storage |
-| `MemoryVectorStore` | In-memory (testing) |
+Custom metadata stays schema-less for storage and round-tripping. Portable *filtering* needs a collection-level `DocumentSchema` passed to the store, because backends differ in what they can filter and how:
 
 ```php
-// Pinecone example
-use NeuronAI\RAG\VectorStore\PineconeVectorStore;
-
-protected function vectorStore(): VectorStoreInterface
-{
-    return new PineconeVectorStore(
-        apiKey: env('PINECONE_API_KEY'),
-        indexName: 'my-index',
-        namespace: 'documents',
-    );
-}
-```
-
-### Document schemas
-
-`Document` is the unified processing object across loading, splitting,
-embedding, storage, retrieval, middleware, and reranking. Its fields are
-accessed through methods. Embedding and score are nullable runtime values;
-strict `null` checks express whether a stage produced them (`0.0` remains a
-valid score).
-
-Custom metadata stays schema-less for storage and round-tripping. Portable
-filtering requires a collection-level schema passed to the vector store:
-
-```php
-$schema = DocumentSchema::of(
+$store = new MemoryVectorStore(schema: DocumentSchema::of(
     DocumentField::string('tenant')->required()->filterable(),
     DocumentField::integer('year')->filterable(),
     DocumentField::strings('tags')->filterable(),
-);
-
-$store = new MemoryVectorStore(schema: $schema);
+));
 ```
 
-Stores validate declared values and filters locally. Only `sourceType`,
-`sourceName`, and declared filterable metadata fields are portable filter
-targets. Array fields are supported for validation/storage but need raw
-backend filters except for portable filterable string arrays, which support
-`containsAny` and `containsAll`. Declared arrays must be non-empty homogeneous
-lists. A `DocumentField` can be passed directly to
-filter factories for schema-aware construction. `neq` requires a required
-field so missing-field behavior cannot diverge between databases. RAG
-validates documents before embedding.
+Only `sourceType`, `sourceName` and declared filterable fields are portable filter targets; stores validate values and filters locally, and RAG validates documents before embedding. Filterable `string[]` fields support `containsAny` / `containsAll`; other array types need raw filters. `neq` requires a required field so missing-field behavior cannot diverge between databases. A `DocumentField` can be passed directly to the filter factories for schema-aware construction.
 
-## Embeddings (`Embeddings/`)
+## Ingestion
 
-`EmbeddingsProviderInterface`:
-
-| Provider | Service |
-|----------|---------|
-| `OpenAIEmbeddingsProvider` | OpenAI text-embedding |
-| `GeminiEmbeddingsProvider` | Google Gemini |
-| `OllamaEmbeddingsProvider` | Local Ollama |
-| `VoyageEmbeddingsProvider` | Voyage AI |
-| `CohereEmbeddingsProvider` | Cohere |
-| `MistralEmbeddingsProvider` | Mistral |
-| `AwsBedrockEmbeddingsProvider` | AWS Bedrock |
-| `OpenAILikeEmbeddings` | Any OpenAI-compatible endpoint |
-
-```php
-use NeuronAI\RAG\Embeddings\GeminiEmbeddingsProvider;
-
-protected function embeddings(): EmbeddingsProviderInterface
-{
-    return new GeminiEmbeddingsProvider(
-        key: env('GEMINI_API_KEY'),
-        model: 'text-embedding-004',
-    );
-}
-```
-
-## Document Loading (`DataLoader/`)
-
-Load and chunk documents:
-
-```php
-use NeuronAI\RAG\DataLoader\FileDataLoader;
-
-$documents = FileDataLoader::for('/path/to/documents')
-    ->withSplitter(new CustomSplitter())
-    ->getDocuments();
-```
-
-### Readers
-
-| Reader | Format |
-|--------|--------|
-| `PdfReader` | PDF files |
-| `HtmlReader` | HTML documents |
-| `TextFileReader` | Plain text |
-
-## Retrieval Strategies (`Retrieval/`)
-
-`RetrievalInterface::retrieve(Message $query, ?FilterExpression $filters = null)`.
-The second parameter carries per-run filters injected via
-`QueryPreProcessedEvent::addFilters()`; a strategy must AND them with its
-own — never drop them. The common RAG path declares its mandatory scope with
-the protected `retrievalScope()` hook (or `setRetrievalScope()` before
-execution):
-
-```php
-use NeuronAI\RAG\VectorStore\Filter\Filter;
-use NeuronAI\RAG\VectorStore\Filter\FilterExpression;
-
-protected function retrievalScope(): ?FilterExpression
-{
-    return Filter::where('tenant', $this->tenantId)
-        ->whereIn('status', ['published', 'reviewed']);
-}
-```
-
-`SimilarityRetrieval` still accepts a `filters:` expression when used
-directly or inside a custom retrieval composition.
-
-## Pre/Post Processors
-
-- `PreProcessor/` - Transform query before retrieval (query expansion, etc.)
-- `PostProcessor/` - Re-rank or filter retrieved documents
-
-## Graph Store (`GraphStore/`)
-
-Knowledge graph integration (Neo4j) using triplet model (subject-relation-object).
-
-## Splitter (`Splitter/`)
-
-Document chunking strategies. Implement `SplitterInterface`:
-
-```php
-use NeuronAI\RAG\Splitter\SplitterInterface;
-use NeuronAI\RAG\Document;
-
-class CustomSplitter implements SplitterInterface
-{
-    public function splitDocument(Document $document): array
-    {
-        // Custom chunking logic
-        return $chunks;
-    }
-
-    public function splitDocuments(array $documents): array
-    {
-        return array_map([$this, 'splitDocument'], $documents);
-    }
-}
-```
+`DataLoader/` (file and string loaders with pluggable readers) → `Splitter/` (`SplitterInterface` chunking strategies) → `Embeddings/` (`EmbeddingsProviderInterface`) → `RAG::addDocuments()` / `reindexBySource()`. `GraphStore/` is the separate knowledge-graph integration (subject-relation-object triplets, Neo4j).

--- a/src/StructuredOutput/AGENTS.md
+++ b/src/StructuredOutput/AGENTS.md
@@ -1,39 +1,20 @@
 # StructuredOutput Module
 
-JSON schema-based extraction with PHP class mapping.
+Turns a PHP class into a JSON Schema for the model, then turns the model's answer back into a validated instance of that class. The PHP class is the single source of truth: property types, nullability and attributes drive schema generation, deserialization and validation alike.
 
-## Core
+## Pipeline
 
-| File | Purpose |
-|------|---------|
-| `JsonSchema.php` | Generates JSON Schema from PHP attributes |
-| `JsonExtractor.php` | Extracts and parses JSON from AI responses |
-| `SchemaProperty.php` | Attribute for custom schema properties |
-| `SchemaPropertiesInterface.php` | Runtime schema property definitions |
+`JsonSchema` (class → schema, from property types and `#[SchemaProperty]` attributes; nested objects, arrays and enums included) → provider call → `JsonExtractor` (finds the JSON inside a free-form answer: fenced blocks, bracket scanning, pluggable extractors) → `Deserializer` (JSON → object) → `Validator` (attribute-driven rules from `Validation/Rules/`).
 
-## Usage
+The Agent's `StructuredOutputNode` runs this pipeline in a retry loop: a deserialization or validation failure is sent back to the model as a correction message and the call is retried up to `maxRetries`. Each attempt is a distinct provider call, so its memo is attempt-indexed and a replay recalls a succeeded attempt without re-calling the provider.
 
-```php
-class UserProfile {
-    #[SchemaProperty(description: 'User name')]
-    public string $name;
+## Runtime schema properties
 
-    #[SchemaProperty(description: 'User age')]
-    public int $age;
-}
-
-$schema = JsonSchema::make(UserProfile::class)->generate();
-// Returns JSON Schema for the class
-```
-
-## Runtime Schema Properties
-
-PHP attribute arguments must be compile-time constants, so `SchemaProperty`
-cannot carry dynamic values (translated descriptions, config-driven constraints).
-Implement `SchemaPropertiesInterface` to build `SchemaProperty` objects at runtime:
+PHP attribute arguments must be compile-time constants, so `#[SchemaProperty]` cannot carry a translated description or a config-driven constraint. `SchemaPropertiesInterface` is the escape hatch: the class builds `SchemaProperty` objects at runtime.
 
 ```php
-class UserProfile implements SchemaPropertiesInterface {
+class UserProfile implements SchemaPropertiesInterface
+{
     public string $name;
 
     #[SchemaProperty(description: 'User age')]
@@ -41,45 +22,9 @@ class UserProfile implements SchemaPropertiesInterface {
 
     public static function schemaProperties(): array
     {
-        return [
-            'name' => new SchemaProperty(description: trans('user.name')),
-        ];
+        return ['name' => new SchemaProperty(description: trans('user.name'))];
     }
 }
 ```
 
-Resolution rules (`SchemaProperty::resolve()`, shared by `JsonSchema` and `Deserializer`):
-- A property listed in `schemaProperties()` uses that object (it replaces the attribute entirely).
-- A property not listed falls back to its `#[SchemaProperty]` attribute.
-- Runtime definitions behave identically to attributes, including `anyOf` array hydration.
-
-The method is static and receives no context: runtime values must come from
-globally reachable state (translator helpers, config, a service locator).
-
-## Schema Generation
-
-Reads PHP attributes and types to generate compatible JSON Schema:
-- String, int, float, bool
-- Arrays and nested objects
-- Optional vs required properties
-- Enum support
-
-## JSON Extraction
-
-`JsonExtractor` handles:
-- Finding JSON in mixed content
-- Parsing code blocks with ```json
-- Repairing malformed JSON
-- Multiple JSON objects
-
-## Validation (`Validation/`)
-
-Post-extraction validation rules.
-
-## Deserializer (`Deserializer/`)
-
-Maps JSON to PHP objects.
-
-## Dependencies
-
-- `Chat` module for message types
+`SchemaProperty::resolve()` is the one resolution point shared by `JsonSchema` and `Deserializer`: a property listed in `schemaProperties()` uses that object and ignores its attribute entirely; anything else falls back to the attribute. The method is static and receives no context, so runtime values must come from globally reachable state (translator helpers, config, a service locator).

--- a/src/Testing/AGENTS.md
+++ b/src/Testing/AGENTS.md
@@ -1,66 +1,22 @@
 # Testing Module
 
-Test fakes and utilities for testing Neuron applications.
+Fakes shipped with the framework so applications, and our own test suite, can exercise real wiring without network or infrastructure. Every fake implements the corresponding framework contract (`AIProviderInterface`, `EmbeddingsProviderInterface`, `VectorStoreInterface`, `WorkflowMiddleware`, `McpTransportInterface`, `StreamingChannelInterface`), so it plugs into the same seam a production implementation would and nothing in the system under test is mocked away.
 
-## Fakes
+## Pattern: queue responses, record calls, assert
 
-| Class | Purpose |
-|-------|---------|
-| `FakeAIProvider` | Mock AI responses, record calls |
-| `FakeEmbeddingsProvider` | Mock embeddings |
-| `FakeVectorStore` | Mock vector store |
-| `FakeMiddleware` | Track middleware execution |
-| `FakeMcpTransport` | Mock MCP transport, record send/receive |
-| `FakeChannel` | Record channel deliveries (sent/lines/suspended states/completions/failures); `throwOnSend` exercises the failure policy |
-| `FakeMessageMapper` | Mock message mapping |
-| `FakeToolMapper` | Mock tool mapping |
-
-## FakeAIProvider Usage
+A fake is pre-loaded with the responses it should return and records everything it receives (`RequestRecord`, `MiddlewareRecord`); assertions read the recording.
 
 ```php
-$provider = new FakeAIProvider();
-$provider->addResponse(new AssistantMessage('Hello!'));
+$provider = new FakeAIProvider(new AssistantMessage('Hello!'));
 
-$agent = Agent::make()->withProvider($provider);
-$response = $agent->chat(new UserMessage('Hi'));
+Agent::make()->setAiProvider($provider)->chat(new UserMessage('Hi'));
 
-// Verify calls
-$provider->assertCalled();
-$provider->assertCalledTimes(1);
+$provider->assertCallCount(1);
+$provider->assertSent(fn (RequestRecord $request): bool => $request->messages[0]->getContent() === 'Hi');
 ```
 
-**PHP Generator Gotcha**: `FakeAIProvider::stream()` uses separate `streamChunks()` method to ensure side effects execute. See project memory for details.
+`FakeMcpTransport` applies the same shape at the JSON-RPC level: queue responses, then `assertMethodSent('initialize')`, `assertToolCalled('search')`, and so on. `FakeChannel` records deliveries (`sent`, `lines`, suspended/completed/failed states) and its `throwOnSend` exercises the workflow's failure policy.
 
-## Record Types
+## Generator gotcha
 
-| Class | Purpose |
-|-------|---------|
-| `RequestRecord` | Captured request details |
-| `MiddlewareRecord` | Captured middleware execution |
-
-## FakeMcpTransport Usage
-
-Test double for `McpTransportInterface`. Queue predetermined responses, then assert what was sent/received.
-
-```php
-$transport = new FakeMcpTransport(
-    ['result' => ['tools' => []]],
-    ['result' => ['content' => 'Hello']],
-);
-
-$transport->connect();
-$transport->send(['method' => 'initialize', 'params' => []]);
-$response = $transport->receive(); // first queued response
-
-$transport->assertConnected();
-$transport->assertMethodSent('initialize');
-$transport->assertInitialized(); // checks initialize + notifications/initialized
-$transport->assertToolsListCalled();
-$transport->assertToolCalled('search');
-```
-
-## Dependencies
-
-- `Providers` module (implements interfaces)
-- `MCP` module (`FakeMcpTransport` implements `McpTransportInterface`)
-- `Workflow` module (`FakeChannel` implements `StreamingChannelInterface`)
+`FakeAIProvider::stream()` must record the call and consume the queued response **eagerly**, then delegate chunk emission to a separate `streamChunks()` generator: a generator body does not run until it is iterated, so side effects placed inside it would never happen for a caller that only checks the recording. Keep that split when touching stream fakes.

--- a/src/Tools/AGENTS.md
+++ b/src/Tools/AGENTS.md
@@ -1,78 +1,18 @@
 # Tools Module
 
-Tool system for agent capabilities. Tools are callable functions exposed to AI.
-
-## Core
-
-| File | Purpose                                                                   |
-|------|---------------------------------------------------------------------------|
-| `ToolInterface.php` | Contract: `getName()`, `getDescription()`, `getProperties()`, `execute()` |
-| `Tool.php` | Base class with property definitions                                      |
-| `ToolCall.php` | The value object a tool invocation travels as (see below)                 |
-| `ToolOutput.php` | Multimodal tool result: wraps content blocks (text, image, file, audio, video) |
-| `ProviderTool.php` | Wrapper for MCP server tools                                              |
-| `ProviderToolInterface.php` | Contract for provider-exposed tools                                       |
+The tool system: callable capabilities exposed to the model. Self-contained.
 
 ## Tool vs ToolCall
 
-A `Tool` is **capability**: schema, `__invoke()`, dependencies (DB connections, HTTP
-clients, closures). It lives on the agent's registry and never travels. A `ToolCall` is
-**conversation data**: the record of one invocation — name, callId, inputs, description,
-result (`string|ToolOutput`, guarded by `hasResult()`), and per-call approval state
-(`ApprovalState` + `approvalReason` + `rejectReason`). ToolCalls are what
-`ToolCallMessage`/`ToolResultMessage`, stream chunks, observability events, persistence,
-and the evaluation Trajectory carry; they are plain data and serialize natively.
-Providers build them (`HandleWithTools::newToolCall()`, validating the name against the
-registry), and `ToolNode` resolves each call back to a live tool at execution — against
-the inference event's tool list only, the cycle's effective set (see
-`src/Agent/AGENTS.md`). A call naming a tool outside that set is a loud `ToolException`,
-never a silent no-op.
-There is no `ToolDefinition` anymore: its data-only stand-in role IS `ToolCall`.
+A `Tool` is **capability**: schema, `__invoke()`, dependencies (DB connections, HTTP clients, closures). It lives on the agent's registry and never travels. A `ToolCall` is **conversation data**: the record of one invocation (name, callId, inputs, result guarded by `hasResult()`, per-call approval state). ToolCalls are what messages, stream chunks, observability events, persistence and the evaluation `Trajectory` carry; they are plain data and serialize natively. There is no separate "tool definition" value object: that role *is* `ToolCall`.
 
-## Creating Custom Tools
+Providers build them (`HandleWithTools::newToolCall()`, validating the name against the registry), and `ToolNode` resolves each call back to a live tool at execution time against the inference request's tool list, the cycle's effective set (`src/Agent/AGENTS.md`). A call naming a tool outside that set is a loud `ToolException`, never a silent no-op. Nothing about a tool, closures included, is ever serialized.
 
-Extend `Tool` and implement required methods:
+## Defining a tool
+
+Extend `Tool`. `name` and `description` are class property defaults, so the constructor stays free for dependencies; `properties()` describes the JSON schema (`ToolProperty`, `ArrayProperty`, `ObjectProperty`), and `__invoke()` receives the inputs as named arguments.
 
 ```php
-use NeuronAI\Tools\Tool;
-use NeuronAI\Tools\ToolProperty;
-use NeuronAI\Tools\PropertyType;
-
-class GetTranscriptionTool extends Tool
-{
-    protected string $name = 'get_transcription';
-
-    protected ?string $description = 'Retrieve the transcription of a YouTube video.';
-
-    protected function properties(): array
-    {
-        return [
-            new ToolProperty(
-                name: 'video_url',
-                type: PropertyType::STRING,
-                description: 'The URL of the YouTube video.',
-                required: true
-            )
-        ];
-    }
-
-    public function __invoke(string $video_url): string
-    {
-        // Your API call logic here
-        return $transcription;
-    }
-}
-```
-
-### Tools with Dependencies
-
-For tools that need constructor dependencies, keep the constructor but set `name` and `description` as class property defaults:
-
-```php
-use NeuronAI\Tools\Tool;
-use NeuronAI\Tools\ToolProperty;
-use NeuronAI\Tools\PropertyType;
-
 class GetTranscriptionTool extends Tool
 {
     protected string $name = 'get_transcription';
@@ -86,272 +26,31 @@ class GetTranscriptionTool extends Tool
     protected function properties(): array
     {
         return [
-            new ToolProperty(
-                name: 'video_url',
-                type: PropertyType::STRING,
-                description: 'The URL of the YouTube video.',
-                required: true
-            )
+            new ToolProperty(name: 'video_url', type: PropertyType::STRING, description: 'The URL of the YouTube video.', required: true),
         ];
     }
 
     public function __invoke(string $video_url): string
     {
-        // Your API call logic here
-        return $transcription;
+        return $this->fetchTranscription($video_url);
     }
 }
 ```
 
-## Multimodal Tool Output
+Toolkits (`AbstractToolkit`) group tools and contribute `guidelines()` to the system prompt; `only()` / `exclude()` / `with()` adjust the provided set per agent. Tool runs are counted by `getRunKey()`, the tool name by default, so `toolMaxRuns()` applies per tool; override it, or use the `TrackByInputs` trait, for parameter-aware limits.
 
-A tool result is `string|ToolOutput` (read from the settled `ToolCall`'s `getResult()`;
-call it only when `hasResult()` is true — a call that never executed, e.g. pending or
-rejected, has no result). Return a
-`ToolOutput` from `__invoke()` to send content blocks (reusing the Chat module's
-`ContentBlockInterface` implementations) back to the model instead of plain text —
-no opt-in interface, the feature is first-class on every tool:
-
-```php
-use NeuronAI\Chat\Enums\MediaType;
-use NeuronAI\Chat\Enums\SourceType;
-use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
-use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
-use NeuronAI\Tools\ToolOutput;
-
-public function __invoke(string $symbol): ToolOutput
-{
-    return new ToolOutput([
-        new TextContent("Price chart for {$symbol}"),
-        new ImageContent($base64, SourceType::BASE64, MediaType::PNG),
-    ]);
-}
-```
-
-Single-block shortcuts: `ToolOutput::text(...)`, `::image(...)`, `::file(...)`,
-`::audio(...)`, `::video(...)` — each mirrors the corresponding content block's
-constructor.
-
-## Tool Failures
+## Results: return value vs exception
 
 The split falls on the natural boundary of the language:
 
-- **Return value = conversational outcome.** A failure the model should see and
-  recover from is *returned*: `return ToolOutput::error('Rate limited, retry after
-  60s');` — a `ToolOutput` whose `isError()` is true, carrying the feedback as a
-  text block. Catch your own exceptions at the tool boundary and convert them
-  visibly.
-- **Escaped exception = bug.** It propagates and aborts the run (fail-fast; the
-  history stays consistent). There is no framework exception class that
-  gets converted to a result.
+- **A return value is a conversational outcome.** A tool returns a string, an array (JSON-encoded) or a `ToolOutput`: a multimodal result built from the Chat module's content blocks (`ToolOutput::text/image/file/audio/video()`, or a block array). A failure the model should see and recover from is *returned*: `ToolOutput::error('Rate limited, retry after 60s')` carries the feedback as a text block with `isError()` true. Catch your own exceptions at the tool boundary and convert them visibly.
+- **An escaped exception is a bug.** It propagates and aborts the run (fail-fast; history stays consistent). There is no framework exception that gets converted into a result. The agent-level `toolErrorHandler(fn (Throwable $e, ToolCall $call): string|ToolOutput|null)` is the cross-cutting override: a returned value settles as the call's result and the loop continues, `null` declines and the exception propagates.
 
-The agent-level `toolErrorHandler(fn (Throwable $e, ToolCall $call):
-string|ToolOutput|null)` is the cross-cutting override for escaped exceptions: a
-returned string or `ToolOutput` settles as the call's result and the loop continues;
-`null` declines and the exception propagates. Providers with a native error concept
-map the flag (`is_error: true` on Anthropic, `status: "error"` on Bedrock);
-elsewhere the feedback text itself carries the semantics. The flag survives the
-chat-history round-trip (see `src/Chat/AGENTS.md`).
+Consumers detect multimodality on the **value** (`$call->getResult() instanceof ToolOutput`), never on the tool type. Providers whose API accepts content blocks map them natively and set their native error flag where one exists; text-only consumers (Ollama, stream adapters, token counting) fall back to `ToolOutput::getText()`, so include a `TextContent` in outputs meant to work everywhere (`ToolOutput` is `Stringable` for the same reason). `ToolNode`'s durable memo records the full `ToolOutput`, so a crash-replay restores multimodal results without re-running the tool.
 
-Consumers detect multimodality on the **value**, never the tool type:
-`$call->getResult() instanceof ToolOutput`. Providers whose API accepts content
-blocks in tool results map them natively; text-only consumers (Ollama, stream
-adapters, token counting) fall back to `ToolOutput::getText()` — the concatenated
-text blocks (empty when there are none, so include a `TextContent` in outputs meant
-to work everywhere). `ToolOutput` is `Stringable` (delegating to `getText()`), so
-string interpolation degrades gracefully.
+## Approval
 
-String and array returns from `__invoke()` behave exactly as before (arrays are
-JSON-encoded). Chat history round-trips a `ToolOutput` result as a content block
-array (see `src/Chat/AGENTS.md`), and `ToolNode`'s durable memo records the full
-`ToolOutput`, so crash-replay restores multimodal results without re-running the
-tool.
-
-## Custom Run Key Tracking
-
-By default, Neuron tracks tool runs by tool name only. This means a tool called multiple times with different parameters counts against the same run limit.
-
-For tools that need custom tracking (e.g., parameter-aware), implement the `getRunKey()` method:
-
-```php
-use NeuronAI\Tools\Tool;
-use NeuronAI\Tools\ToolProperty;
-use NeuronAI\Tools\PropertyType;
-
-class ReadFileTool extends Tool
-{
-    protected string $name = 'read_file';
-
-    protected ?string $description = 'Read a portion of a file.';
-
-    protected function properties(): array
-    {
-        return [
-            ToolProperty::make('path', PropertyType::STRING, 'File path', true),
-            ToolProperty::make('offset', PropertyType::INTEGER, 'Byte offset', true),
-            ToolProperty::make('length', PropertyType::INTEGER, 'Bytes to read', true),
-        ];
-    }
-
-    public function __invoke(string $path, int $offset, int $length): string
-    {
-        // Read file portion
-        return file_get_contents($path, false, null, $offset, $length);
-    }
-
-    public function getRunKey(): string
-    {
-        // Track runs by path and offset, allowing different offsets
-        return $this->getName() . ':' . $this->getInput('path') . ':' . $this->getInput('offset');
-    }
-}
-```
-
-Alternatively, use the `TrackByInputs` trait for automatic input-based keys:
-
-```php
-use NeuronAI\Tools\TrackByInputs;
-
-class ReadFileTool extends Tool
-{
-    use TrackByInputs;
-}
-```
-
-## Property Types
-
-| Class | JSON Schema Type |
-|-------|------------------|
-| `ToolProperty` | string, number, boolean (via `PropertyType` enum) |
-| `ArrayProperty` | array with item schema |
-| `ObjectProperty` | object with nested properties |
-
-## Usage with Agent Extension Pattern
-
-Register tools in your custom agent class:
-
-```php
-use NeuronAI\Agent;
-use NeuronAI\Providers\AIProviderInterface;
-use NeuronAI\Providers\Anthropic\Anthropic;
-use NeuronAI\SystemPrompt;
-
-class YouTubeAgent extends Agent
-{
-    protected function provider(): AIProviderInterface
-    {
-        return new Anthropic(
-            key: env('ANTHROPIC_API_KEY'),
-            model: 'claude-sonnet-4-6',
-        );
-    }
-
-    public function instructions(): string
-    {
-        return (string) new SystemPrompt(
-            background: ['You are an AI agent specialized in writing YouTube video summaries.'],
-            steps: [
-                'Get the URL of a YouTube video, or ask the user to provide one.',
-                'Use the tools you have available to retrieve the transcription of the video.',
-                'Write the summary.',
-            ],
-            output: [
-                'Write a summary in a paragraph without using lists.',
-                'After the summary add a list of three sentences as the most important takeaways.',
-            ]
-        );
-    }
-
-    protected function tools(): array
-    {
-        return [
-            new GetTranscriptionTool(env('SUPADATA_API_KEY')),
-        ];
-    }
-}
-
-// Usage
-use NeuronAI\Chat\Messages\UserMessage;
-
-$response = YouTubeAgent::make()->chat(
-    new UserMessage('Summarize this: https://youtube.com/watch?v=...')
-);
-```
-
-## Toolkits (`Toolkits/`)
-
-Group related tools. Extend `AbstractToolkit`:
-
-```php
-use NeuronAI\Tools\Toolkits\AbstractToolkit;
-
-class MyToolkit extends AbstractToolkit
-{
-    public function guidelines(): ?string
-    {
-        return "Guidelines go into the system prompt of the agent to help the model use the tools provided below.";
-    }
-
-    public function provide(): array
-    {
-        return [
-            new ToolA(),
-            new ToolB()
-        ];
-    }
-}
-
-// In agent
-protected function tools(): array
-{
-    return [
-        new MyToolkit(),
-    ];
-}
-```
-
-### Built-in Toolkits
-
-| Toolkit | Purpose |
-|---------|---------|
-| `Calculator/` | Math operations |
-| `MySQL/` | MySQL database queries |
-| `PGSQL/` | PostgreSQL queries |
-| `Tavily/` | Web search API |
-| `Zep/` | Zep memory integration |
-| `AWS/` | AWS services (SES, etc.) |
-| `Jina/` | Jina AI embeddings |
-| `Supadata/` | Supadata API |
-| `FileSystem/` | File operations |
-| `Calendar/` | Calendar operations |
-
-## Retrieval Tool
-
-`RetrievalTool.php` - Generic tool for RAG document retrieval.
-
-## Tool Approval
-
-A tool declares its own intrinsic risk by overriding the protected
-`approvalPolicy(array $inputs): bool|string` hook (default `false`). Declarations are
-**live by default**: `ToolNode` asks every tool on every call — no middleware
-or agent-level switch exists. The agent developer overrides the declaration per instance,
-at attach time, in both directions:
-
-- `requireApproval(bool $require = true)` — force the gate's answer either way.
-- `suppressApproval()` — sugar for `requireApproval(false)`; waives a declared gate.
-- `withApprovalPolicy(callable $policy)` — replace the policy with a
-  `fn(ToolInterface $tool): bool|string` callback.
-
-The last configured override wins (each clears the other). The public
-`requiresApproval(array $inputs)` on `ToolInterface` is the *resolution point* the node
-consults: override → declaration. The node always asks the LIVE registry tool with the
-call's inputs bound, so the answer cannot drift across a suspend/resume
-boundary — and nothing about the tool (closures included) is ever serialized.
-
-Returning a **string counts as `true`** and doubles as the approval reason — the outbound
-"why am I asking" shown to the approver, surfaced on the `ApprovalRequest` actions and
-persisted on the tool entry (`getApprovalReason()` / `approvalReason` in the serialized
-message):
+A tool declares its own intrinsic risk through the protected `approvalPolicy(array $inputs): bool|string` hook (default `false`); a string counts as `true` and doubles as the approval reason shown to the approver. Declarations are live: `ToolNode` asks every tool on every call, with the call's inputs bound, so the answer cannot drift across a suspend/resume boundary. There is no middleware and no agent-level switch to attach.
 
 ```php
 class TransferMoneyTool extends Tool
@@ -365,14 +64,6 @@ class TransferMoneyTool extends Tool
 }
 ```
 
-Per-call approval state (`pending` / `approved` / `rejected`) is stamped on the
-`ToolCall` entries of the `ToolCallMessage` and persisted in **chat history** — that is
-the system of record, not workflow state. See `ApprovalState`. Two reasons may
-accompany it, with opposite directions: `approvalReason` (outbound, the requester's
-purpose) and `rejectReason` (inbound, the approver's feedback — rejection-only, recorded
-via `ToolCall::setApprovalState(ApprovalState::Rejected, $reason)` and read via
-`getRejectReason()`).
+The agent developer overrides the declaration per instance at attach time, in both directions: `requireApproval()` forces the gate, `suppressApproval()` waives a declared one, `withApprovalPolicy(fn (ToolInterface $tool): bool|string)` replaces the policy. The last override wins. `ToolInterface::requiresApproval(array $inputs)` is the resolution point the node consults: override first, then declaration.
 
-## Dependencies
-
-None. Tools module is self-contained.
+Per-call approval state (`ApprovalState`: pending / approved / rejected) is stamped on the `ToolCall` entries of the `ToolCallMessage` and persisted in **chat history**, the system of record for approvals; workflow state holds none of it. Two reasons travel with it in opposite directions: `approvalReason` (outbound, why the tool asked) and `rejectReason` (inbound, the approver's feedback, recorded on rejection only). The resume flow is described in `src/Agent/AGENTS.md`.

--- a/src/Workflow/AGENTS.md
+++ b/src/Workflow/AGENTS.md
@@ -1,30 +1,22 @@
-# Workflow module
+# Workflow Module
 
-Workflow is Neuron's event-driven orchestration foundation. Agent and RAG are
-compositions built on it.
+Neuron's event-driven orchestration foundation. Agent and RAG are compositions built on it; nothing here knows about AI providers, chat or tools.
 
 ## Core model
 
-Workflows route events through nodes until a `StopEvent`:
-
-```text
-StartEvent -> NodeA -> EventA -> NodeB -> StopEvent
-```
-
-A node's `__invoke()` input type determines routing. The executor owns traversal,
-durable replay, suspension, and lifecycle transitions; nodes remain unaware of
-workers, HTTP requests, queues, or cloud platforms.
+A workflow routes events through nodes until a `StopEvent`. A node's `__invoke()` input type determines routing; the executor owns traversal, durable replay, suspension and lifecycle transitions, while nodes stay unaware of workers, HTTP requests, queues or cloud platforms.
 
 ```php
-$workflow = Workflow::make(state: $state)
-    ->addNodes([new NodeA(), new NodeB()]);
-
-$state = $workflow->run();
+$state = Workflow::make(state: $state)
+    ->addNodes([new NodeA(), new NodeB()])
+    ->run();
 ```
 
-## Suspend, inspect, and resume
+Subclasses build their graph in the `nodes()` / `entryNodes()` hooks, which run fresh at every execution segment, so the graph is always a function of the current configuration. Middleware wraps node execution (`addMiddleware(NodeClass::class, ...)`, subclass-aware, or `addGlobalMiddleware()`): it shapes events before a node acts, while flow control and I/O belong to nodes. Keep platform integration outside middleware and executors; the returned lifecycle outcome is the integration boundary.
 
-Nodes suspend through focused helpers:
+## Suspend, inspect, resume
+
+Nodes pause through focused helpers, each producing a portable `InterruptRequest` (`WaitForEventRequest`, `SleepUntilRequest`, `ApprovalRequest`, or your own serializable subclass):
 
 ```php
 $payload = $this->awaitEvent('order.approved', expiresAt: $deadline);
@@ -32,351 +24,62 @@ $this->sleepUntil($wakeAt);
 $payload = $this->interrupt(new MyApprovalRequest(...));
 ```
 
-`InterruptRequest` is the canonical, portable description of the pause. The
-executor assigns its ID, persists it, and returns the same ID-bound value to
-the caller. Request subclasses may add portable presentation metadata but must
-remain serializable:
+The executor assigns each interrupt a positive, run-scoped, monotonically increasing ID, persists it, and returns the same ID-bound request through `$state->getInterruptRequests()`. Parallel branches may expose several active interrupts at once; a partial resume runs only the addressed nodes and returns the unaddressed requests from persistence without rerunning theirs.
 
-```php
-$state = $workflow->run();
+Two continuation styles share one model:
 
-foreach ($state->getInterruptRequests() as $request) {
-    // getId(), type(), plus request-specific coordination and metadata
-}
-```
+- **Application code** resumes by signal name: `$workflow->signal('order.approved', $payload)->run()`. The signal is delivered to every currently active `awaitEvent()` with that name, parallel branches included, and is never queued: with no matching wait, `signal()` throws without persisting the payload. Use distinct names or a correlation key when delivery must target one wait.
+- **Durable platform SDKs** pass addressed, typed inputs: `run([ResumeInput::event($request, $payload), ResumeInput::timer($sleepRequest), ...], expectedRunId: $runId)`. Nodes never see `ResumeInput`; the executor translates an accepted input into the node's normal return (payload, `null` on expiry, timer wake). One input settles exactly one interruption. Once accepted it is immutable until the step settles (an identical redelivery may recover a failed attempt, a different answer rejects the batch); stale or unknown IDs are reported through `getInputResults()`, and a stale `expectedRunId` rejects the whole batch before traversal.
 
-Application code normally resumes an event wait by signal name:
-
-```php
-$state = $workflow
-    ->signal('order.approved', ['approved' => true])
-    ->run();
-```
-
-The signal is delivered to every currently active `awaitEvent()` with that
-name, including waits in parallel branches. It is never queued: when no active
-wait matches, `signal()` throws a `WorkflowException` without persisting the
-payload. Use distinct names or a domain correlation key when delivery must
-target only one wait.
-
-Call `events()` instead of `run()` after `signal()` to stream the resumed segment.
-
-Every interrupt receives a positive, run-scoped, monotonically increasing ID.
-Parallel branches may expose multiple active interrupts at once. A partial
-resume executes only addressed interrupted nodes; unaddressed requests are
-returned directly from persistence without rerunning their nodes.
-
-Durable platform SDKs use addressed, typed inputs:
-
-```php
-use NeuronAI\Workflow\Interrupt\ResumeInput;
-
-$state = $workflow->run([
-    ResumeInput::event($eventWaitRequest, ['approved' => true]),
-    ResumeInput::expired($expiredEventWaitRequest),
-    ResumeInput::timer($sleepRequest),
-]);
-```
-
-- `event` targets `wait_for_event`.
-- `expired` and `timer` remain available to infrastructure integrations, but
-  ordinary timer coordination invokes `run([])` and lets Workflow
-  determine which waits are due.
-- Event payloads must be JSON-compatible arrays; `{}`/`[]` is a real empty
-  answer.
-- A matching-run batch accepts active IDs and reports already-settled/unknown
-  IDs as `stale` through `WorkflowState::getInputResults()`.
-- Once accepted, an interrupt's input is immutable until the step settles.
-  Redelivery with the same kind and JSON payload may recover a failed attempt;
-  a different answer rejects the batch before claiming execution.
-- A stale `expectedRunId` rejects the whole batch before traversal.
-
-For directly controlled current-run continuation, `expectedRunId` may be
-omitted. A durable SDK or delayed delivery supplies the `runId` copied from the
-earlier outcome:
-
-```php
-$state = $workflow->run($inputs, expectedRunId: $runId);
-```
-
-An inputless continuation evaluates the clock and resolves every active
-`sleepUntil()` or expiring `awaitEvent()` whose deadline is due. It also replays
-a crashed or failed attempt without inventing an external answer. Future waits
-remain suspended:
-
-```php
-$state = $workflow->run(
-    [],
-    expectedRunId: $runId,
-    expectedExecutionAttempt: $attempt,
-);
-```
-
-Streaming uses the same continuation model. `events()` starts a run;
-`signal($name, $payload)->events()` delivers an application signal;
-`events()` continues with addressed platform inputs, and `events([])` performs inputless continuation. Fences require the explicit input array.
-
-Nodes never receive `ResumeInput`. The executor translates an accepted input
-into the existing node semantics: event payload, timeout null, or timer wake.
-One input satisfies exactly one interruption, including payload-less expiry and
-timer inputs.
+`run()` / `events()` express both start and continuation: no argument ignites a new run, an explicit array continues one. `run([])` is the inputless continuation: it evaluates the clock, resolves every due `sleepUntil()` or expiring `awaitEvent()`, and replays a crashed or failed attempt without inventing an external answer. `events()` streams the same segments (`signal(...)->events()` streams a resumed one).
 
 ## Platform-owned coordination
 
-Workflow core does not depend on a scheduler or coordination platform. There is
-no scheduler interface and no suspend/resume/complete callback from the
-executor.
+The core has no scheduler interface and no suspend/resume/complete callbacks. A platform SDK is an invocation gateway: reconstruct the workflow and its live dependencies through its own factory, configure persistence, serializer, lease and completion retention, call `run()` with addressed inputs or `[]`, inspect the returned status, run ID, input dispositions and active interrupts, then reconcile its own timers, subscriptions and jobs. HTTP round trips, queue workers and CLI loops are equivalent callers; platform job IDs, delivery attempts and factory identity never enter Workflow persistence.
 
-A platform SDK is an invocation gateway:
+The complete `InterruptRequest` stays authoritative in Workflow persistence; a platform stores only the projection it needs to route work (`workflowId`, `runId`, `interruptId`, type, event name, deadline). A delivery job resolves the interrupt-ID set when a signal is first accepted and reuses exactly that set on every retry; it never rematches by name after a lost response. For timers it stores identity plus the earliest deadline and invokes `run([])`. Reconstruction is the factory's job: ignition context may restore small domain identity (the Agent's thread ID), but it is not a dependency container.
 
-1. reconstruct the Workflow and all live dependencies through its own factory;
-2. configure persistence, serializer, lease, and completion retention;
-3. call `run()` with addressed inputs or `[]` for inputless continuation;
-4. inspect the returned status, run ID, input dispositions, and complete active
-   interrupt set;
-5. durably reconcile the platform's timers, subscriptions, and jobs.
+## One partition, optimistic ownership
 
-This makes HTTP round trips, queue workers, CLI loops, and other infrastructures
-equivalent callers. Platform job IDs, delivery attempts, scheduler commands,
-and factory identity do not enter Workflow persistence.
-
-`WorkflowState::getWorkflowId()`, `getRunId()`, and `getExecutionAttempt()` expose
-portable ownership identity. `getStatus()`, `getInputResults()`, and
-`getInterruptRequests()` expose the lifecycle result.
-
-The complete `InterruptRequest` remains authoritative in Workflow persistence.
-The platform stores only a JSON projection needed to route or schedule work:
-`workflowId`, `runId`, `interruptId`, type, event name, deadline, and its own job
-metadata. A delivery job stores the interrupt-ID set resolved when the external
-signal was first accepted and reuses exactly that set on every retry; it never
-rematches by signal name after a lost response. The request object itself is
-never sent back as continuation input.
-
-For timers, the platform stores the workflow/run identity and earliest deadline,
-then invokes `run([])`. Workflow validates the clock and selects all
-currently due waits. `expectedExecutionAttempt` is available for exact recovery
-fencing but is normally omitted from delayed event delivery because legitimate
-recovery may advance the execution attempt.
-
-Reconstruction is explicitly the application/platform SDK factory's
-responsibility. Ignition context may restore small domain identity, but it is not
-a dependency container or core factory registry.
-
-## One partition and optimistic ownership
-
-All records for a Workflow ID stay in one persistence partition:
+All records for a workflow ID live in one persistence partition:
 
 | key | purpose |
 |---|---|
-| `__ignition` | immutable start event, run ID, and engine-opaque context |
-| `__control` | mutable lifecycle authority and optimistic condition value |
-| `<runId>/__checkpoint` | the suspended run's state, returned by a continuation whose inputs are all stale |
-| `<runId>/__outcome` | the retained terminal state, only when completion retention is enabled |
-| `<runId>/<stepId>` | durable step result or marker; branch steps include a hash of their complete parent-fork path |
+| `__ignition` | immutable start event, run ID, engine-opaque context |
+| `__control` | mutable lifecycle authority: run ID, status, execution attempt, lease deadline, next interrupt ID, active interrupts with their accepted inputs |
+| `<runId>/__checkpoint` | the suspended run's state |
+| `<runId>/__outcome` | the retained terminal state (completion retention only) |
+| `<runId>/<stepId>` | durable step result or marker (branch steps hash their parent-fork path) |
 | `<runId>/<stepId>::<memo>` | durable memo result |
 
-`__control` contains the current run ID, status, monotonic execution attempt,
-optional lease deadline, next interrupt ID, and the active interrupts with
-their accepted inputs. It never carries workflow state: the suspended
-checkpoint and the retained outcome are separate records written in the same
-conditional write, so the fence stays small. Like steps, they are keyed under
-the run ID, so a process holding an older control reads its own generation's
-state or nothing, never a successor's.
-
-Every runtime mutation uses one of the explicit atomic persistence operations:
-`initializeIfAbsent()`, `writeIfUnchanged()`, or `deleteIfUnchanged()`. Writes
-and deletion expect the byte-identical control value from which they were
-derived. A successful claim increments `executionAttempt`; an older process can
-still finish local work, but it cannot commit a step, memo, suspension, failure,
-or cleanup after a new owner changes control.
-
-This is optimistic ownership in plain terms:
+`PersistenceInterface` offers `get()` plus three atomic intents, `initializeIfAbsent()`, `writeIfUnchanged()` and `deleteIfUnchanged()`; there is no unconditional runtime write or delete. Every mutation is derived from a byte-exact read of `__control` and commits only if control still holds that value:
 
 ```text
 read control A -> calculate transition -> write only if control is still A
 ```
 
-The persistence backend treats all keys and values as opaque strings. It does
-not understand runs, attempts, leases, or suspensions.
+A successful claim increments the execution attempt; an older process may finish local work but can no longer commit a step, memo, suspension, failure or cleanup. `__control` never carries workflow state (checkpoint and outcome are separate records written in the same conditional write, keyed under the run ID, so an older process reads its own generation's state or nothing). The backend treats keys and values as opaque strings and understands nothing about runs. `WorkflowRunStore` is the internal boundary that owns reserved keys, serialization, the control snapshot, conditional writes and a segment-local record cache; `StepMemoizer` is a step-bound view of it; `WorkflowExecutor` works with typed `WorkflowControl` and never touches raw bytes.
 
-`WorkflowRunStore` is the internal boundary between lifecycle traversal and
-that low-level persistence contract. It owns the reserved keys, serialization,
-the current byte-exact control snapshot, step and memo keys, conditional record
-writes, and conditional partition cleanup. It also keeps a segment-local cache
-of the run's records: after igniting, unknown step and memo keys are absent
-without a backend read, and on a continuation each key is read at most once.
-The cache holds serialized bytes and only what confirmed writes committed, and
-it is discarded whenever control is reloaded. `StepMemoizer` is a step-bound view of
-this same store; it does not access persistence or serialization directly. `WorkflowExecutor` works with typed
-`WorkflowControl` instances and does not track raw persisted control values.
-
-## Execution lease
-
-Leases are opt-in for a plain Workflow; `Agent` holds one by default (ten
-minutes, see `src/Agent/AGENTS.md`):
-
-```php
-$workflow->setLeaseTimeout(300);
-```
-
-The lease deadline lives inside `__control`; there is no separate lease record.
-Every step commit renews it in the same conditional write as the step record,
-so a heartbeat never costs a write of its own. Suspension and caught failure
-clear it because no process is intentionally executing. A process killed with
-no chance to write (memory limit, execution timeout, OOM kill) leaves the
-record `running`: without a lease only `run([])` can take it over; with one,
-the next ignition supersedes it once the deadline passes. An inputless
-continuation worker may take over a `running` attempt only when leases are
-disabled or the enabled lease has expired. The conditional claim still ensures
-only one contender advances the attempt.
-
-A lease is a crash-overlap safeguard, not proof that the prior process died.
-Choose a timeout longer than the longest silent node operation, and use external
-idempotency for uncertain side effects.
-
-## Failed and dead generations
-
-A caught failure commits `failed` into `__control` and leaves the partition in
-place. Two verbs settle it:
-
-- `run([])` replays the generation: committed steps and memos are reused and
-  only the failed step runs again. The run ID is unchanged.
-- A fresh `run()` at the same workflow ID supersedes it: the dead generation
-  is conditionally swept and a new generation ignites with the new start event.
-
-A `running` generation whose lease deadline has expired is dead in the same
-sense (the process never committed again) and is superseded the same way.
-Suspended generations, retained completions, and `running` generations with
-no lease deadline or a fresh one still refuse a fresh ignition. The sweep is
-fenced by the control bytes just read: a recovery worker that claims the
-generation first keeps it, and the ignition is refused.
-
-The refusal is a `RunInFlightException` (a `WorkflowException`) describing the
-generation that holds the ID: `runId`, `status`, `executionAttempt`,
-`leaseExpiresAt`, and the active `interrupts`. Its message names the verb that
-settles that state: deliver the awaited input, acknowledge the retained
-completion, wait for the lease, or configure a lease so a dead run can be
-superseded next time.
-
-Application code can also discard a run without igniting a new one:
-
-```php
-$abandoned = $workflow->abandonRun();          // false when nothing is in flight
-$workflow->abandonRun(expectedRunId: $runId);  // a stale fence throws
-```
-
-A suspended, failed, or unleased or lease-expired running generation is
-deleted behind the same fence. A retained completion refuses (acknowledge it
-instead), and so does a run under a fresh lease (a worker is executing it).
-
-## Completion and cleanup
-
-Manual workflows clean up by default. A clean `StopEvent` conditionally deletes
-the whole owned partition, so completed step data does not grow indefinitely and
-the Workflow ID becomes available for a new generation.
-
-A platform SDK that must survive a lost completion response opts into retained
-completion at construction time:
-
-```php
-$workflow->retainCompletionUntilAcknowledged();
-```
-
-The executor then commits `completed` into `__control` and the terminal state
-into `<runId>/__outcome` in one conditional write. Retries replay the same
-terminal state without executing nodes. After the
-platform durably records the outcome, it purges the exact generation:
-
-```php
-$workflow->acknowledgeCompletion($runId);
-```
-
-Acknowledgement requires the retained run ID and control value. Core keeps
-no permanent history; history belongs to the platform or application.
-
-## Persistence backends
-
-`PersistenceInterface` provides `get()` plus three explicit atomic mutation
-intents: initialize an absent condition key and its records, write records while
-the condition value is unchanged, and delete a partition while the condition
-value is unchanged. There is no unconditional runtime write or delete path.
-Production multi-worker backends must perform each condition check and its
-complete mutation in one database transaction or equivalent storage-native
-atomic operation.
-
-- `DatabasePersistence` and `EloquentPersistence` are the built-in
-  multi-process candidates.
-- `InMemoryPersistence` is process-local.
-- `FilePersistence` provides restart durability for controlled single-process
-  use only. It is deliberately not a worker-farm lock manager. Corrupt or
-  unreadable files fail loudly rather than appearing absent.
-
-All backends preserve one silo per Workflow: one array, one directory containing
-one file per partition, or one table keyed by `(partition, key)`.
-
-SQL backends encode identifiers as hex and values as base64. Serializers return
-raw bytes, and transport encoding belongs to persistence. The SQL schema in
-`DatabasePersistence` supports identifiers up to 255 bytes (510 encoded
-characters); MySQL requires strict mode and an InnoDB table. `EloquentPersistence`
-uses the model's table and connection with this same SQL implementation, including
-Laravel-managed transactions. Model scopes, casts, and events do not transform
-opaque engine records.
-
-The SQL integration tests run competing processes against SQLite by default.
-Set `WORKFLOW_MYSQL_DSN`, `WORKFLOW_MYSQL_USER`, `WORKFLOW_MYSQL_PASSWORD` and/or
-`WORKFLOW_PGSQL_DSN`, `WORKFLOW_PGSQL_USER`, `WORKFLOW_PGSQL_PASSWORD` to include
-MySQL/MariaDB and PostgreSQL. Tests create and drop uniquely named tables in the
-configured test database.
+Backends: `DatabasePersistence` and `EloquentPersistence` are the multi-process candidates and must perform each condition check and its mutation in one transaction; `InMemoryPersistence` is process-local; `FilePersistence` gives restart durability for controlled single-process use only and is deliberately not a worker-farm lock manager. Serializers return raw bytes; transport encoding belongs to persistence.
 
 ## Durable steps and memoization
 
-Every completed node step is persisted and skipped on replay. If a node fails
-before its step result commits, it runs again. Failure updates run control without
-writing a failed-step marker: an absent step executes again, and an interrupted
-step retains its marker and accepted input. Replaying a completed step restores
-the traversal's local state, including inside isolated parallel branches.
+Every completed node step is persisted and skipped on replay; a node that fails before its step commits runs again (failure updates control without writing a failed-step marker). Inside a node, `memoize('name', fn () => ...)` makes an expensive or non-deterministic sub-operation replay-safe; the memo write is fenced by the same control record as step writes. It reuses committed results, it cannot make an uncertain external side effect exactly-once: supply an idempotency key to the external system where that matters. `recallMemo()` is the read-only counterpart for streaming flows.
 
-Use `memoize()` around expensive or non-deterministic sub-operations:
+`restoreState()` reattaches transient dependencies to state recalled from persistence (completed steps, unaddressed interrupts, checkpoints, retained outcomes); it is never called on live results. Serialization and cloning are separate contracts: parallel branches work on clones, so state subclasses with mutable object properties outside the data array must define how they clone.
 
-```php
-$result = $this->memoize('provider-call', fn () => $provider->invoke(...));
-```
+## Leases, failures, dead generations
 
-The successful memo write is fenced by the same control record as step writes.
-`memoize()` reuses committed results; it cannot make an uncertain external side
-effect exactly once. Supply a provider/application idempotency key where that
-matters. `recallMemo()` remains the read-only counterpart for streaming flows.
+Leases are opt-in (`setLeaseTimeout()`; `Agent` holds a ten-minute one by default). The deadline lives inside `__control` and every step commit renews it in the same conditional write, so a heartbeat costs nothing; suspension and caught failure clear it. A process killed with no chance to write leaves the record `running`: without a lease only `run([])` can take it over, with one the next ignition supersedes it once the deadline passes. A lease is a crash-overlap safeguard, not proof the prior process died: choose a timeout longer than the longest silent node operation.
 
-## Executors and middleware
+A caught failure commits `failed` and leaves the partition in place. `run([])` replays the generation (committed steps and memos reused, only the failed step reruns, same run ID); a fresh `run()` supersedes it with a new generation. A `running` generation whose lease expired is dead in the same sense. Suspended generations, retained completions and live leases refuse a fresh ignition with `RunInFlightException`, whose message names the verb that settles that state (deliver the awaited input, acknowledge the completion, wait for the lease). `abandonRun()` discards a paused, failed or dead run without igniting a new one; a retained completion or a fresh lease refuses. Every sweep is fenced by the control bytes just read, so a recovery worker that claims first keeps the generation.
 
-`WorkflowExecutor` owns lifecycle decisions and sequential traversal.
-`WorkflowRunStore` owns the persistence protocol used to commit those
-decisions. `AsyncExecutor` changes only parallel branch execution and returns
-all active interruptions; storage and coordination ownership do not change.
+## Completion
 
-A workflow instance runs one segment at a time. Starting another `run()` or
-`events()`, or calling `abandonRun()` or `acknowledgeCompletion()`, while a
-segment's generator is still in flight throws a `WorkflowException` before
-anything is touched. Discarding the generator releases the instance; the run
-it leaves behind is settled by the usual durability rules.
+A clean `StopEvent` conditionally deletes the whole partition by default, so completed data does not grow and the workflow ID is free for a new generation. A platform that must survive a lost completion response opts into `retainCompletionUntilAcknowledged()`: the terminal state is committed to `<runId>/__outcome` together with `completed` control, retries replay it without executing nodes, and `acknowledgeCompletion($runId)` purges that exact generation. Core keeps no permanent history; history belongs to the platform or application.
 
-Executors type against `WorkflowRuntimeInterface`, which exposes definition,
-state, persistence, serializer, lease configuration, completion-retention
-policy, ignition, and bootstrap. Application code uses `WorkflowInterface`.
+## Executors and streaming
 
-`Workflow::restoreState()` reattaches transient dependencies to state recalled from
-completed steps, unaddressed interruption markers, checkpoints, and retained
-outcomes. It receives the actual local state, including branch state, and is never
-called on live results. The default returns state unchanged. Serialization and
-cloning are separate contracts: state subclasses with mutable object properties
-outside the data array must define how those properties are cloned.
+`WorkflowExecutor` owns lifecycle decisions and sequential traversal; `AsyncExecutor` changes only parallel branch execution. Executors type against `WorkflowRuntimeInterface`; application code uses `WorkflowInterface`. A workflow instance runs one segment at a time: starting another `run()` or `events()`, or calling `abandonRun()` / `acknowledgeCompletion()`, while a segment's generator is in flight throws before anything is touched.
 
-Middleware wraps node execution:
-
-```php
-$workflow->addMiddleware(NodeClass::class, new LoggingMiddleware());
-$workflow->addGlobalMiddleware(new PerformanceMiddleware());
-```
-
-Keep platform integration outside middleware and executors. The returned
-lifecycle outcome is the integration boundary.
+Nodes may `yield` live output while a segment streams; `setStreamAdapter()` converts it to protocol lines once, for both pull consumers and an attached `StreamingChannelInterface` (`send()` for native objects, `sendLine()` for lines). Yielded output is ephemeral and never replayed; see `src/Chat/Messages/Stream/Adapters/AGENTS.md`.


### PR DESCRIPTION
## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔧 Improvement/Enhancement (non-breaking change which improves existing functionality)
- [x] 📖 Documentation update
- [ ] 🧹 Code cleanup/refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

### What does this PR do?

Rewrites the fourteen module `AGENTS.md` files under `src/` so each one carries only what the source cannot say on its own: the mental model of the module, the architectural decisions and the reasons behind them, the invariants the machinery relies on, and a code example where a pattern or a developer-experience choice needs to be shown rather than described.

The module guides go from 3109 lines to 720. The root `AGENTS.md` and `upgrade/AGENTS.md` are untouched, since both already speak in principles and process. Every module `CLAUDE.md` still includes its guide through `@AGENTS.md`, so nothing changes in how the context is loaded.

Removed: file-by-file tables, the full lists of providers, vector stores, embeddings providers and toolkits, alternative-provider snippets, CLI recipes, the `composer.json` autoload setup, per-module "Dependencies" sections that duplicated the root table, and the "Verification expectations" checklist in the stream adapters spec.

Kept and compressed: the Workflow partition layout and optimistic-ownership loop, "the thread is the workflow ID", the commit-after-success rule for history writes, the cumulative approval payload, the filter model and schema decisions in RAG, the return-value-vs-exception rule for tool failures, and the run-output cache design in Evaluation. Each now appears once instead of being restated across files.

Stale claims found while verifying every referenced symbol against the current source were corrected rather than carried forward: the `Agent` and `SystemPrompt` namespaces (`NeuronAI\Agent\...`, not `NeuronAI\...`), `FakeAIProvider` assertion names that no longer exist, MCP tools described as `ProviderTool` when they are `McpTool` subclasses of `Tool`, and a Vercel adapter caveat demanding a fix for a lazy-start bug the code already handles.

### Why is this change needed?

These files are the initial context an AI coding assistant loads to understand a module. They had grown into internal reference manuals documenting every detail, which an agent recovers faster and more reliably from the source itself. Focusing them on philosophy, architecture and design decisions gives the assistant what it cannot infer from reading code, and keeps the guides from drifting out of date as quickly.

### How does this change should be used and documented?

No further documentation is needed. The guides are consumed automatically through the module `CLAUDE.md` includes, and their new shape is the convention for future edits: add a section only for a decision, an invariant or a pattern, never for a list of files or implementations.

## Related Issues

- None

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated unit tests where appropriate
- [ ] All existing tests pass
- [ ] I have tested this with different PHP versions (if applicable)

Documentation-only change, no PHP code touched, so the test suite was not run. Every class, method, constructor parameter and config key mentioned in the new text was checked against the current source before writing, and every code fence was checked for balance.

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces breaking changes (explain below)

## Documentation

- [ ] No documentation changes needed
- [x] I have updated relevant documentation
- [ ] Documentation will be updated in a separate PR
- [ ] New documentation needs to be created

## Checklist

- [ ] My code follows the project's coding standards (PHPStan)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] My commit messages are clear and descriptive
- [x] This PR addresses only ONE specific goal/issue

PHPStan does not apply to Markdown files.

## Additional Notes

The Observability guide still describes the deprecated `ObserverInterface` / `LogObserver` / `ObserverAdapter` path in three lines. Given that this branch is a new major with no backward-compatibility obligation, that path is a candidate for removal from the code itself. That is a code change outside the scope of this PR, so it was left in place and documented as transitional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gvx9SE5zWWU5aRKnYPPTcA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gvx9SE5zWWU5aRKnYPPTcA)_