### PR TITLE
Archive trimmed chat messages instead of deleting them

### DIFF
--- a/src/Chat/AGENTS.md
+++ b/src/Chat/AGENTS.md
@@ -17,7 +17,11 @@ new UserMessage([
 
 ## Chat history
 
-`AbstractChatHistory` implements the logic once; backends persist through one protected hook per primitive mutation, append (`onNewMessage`), head-trim (`onTrimHistory`) and clear, or ignore the hooks and rewrite the whole state via `setMessages()` (File, InMemory). SQL and Eloquent backends store one row per message keyed by thread. `HistoryTrimmer` keeps the thread inside the context window by estimating tokens and dropping the oldest messages first.
+`AbstractChatHistory` implements the logic once; backends persist through one protected hook per primitive mutation, append (`onNewMessage`), head-trim (`onTrimHistory`, handed the trimmed messages) and clear, or ignore the hooks and rewrite the whole state via `setMessages()` (File, InMemory). SQL and Eloquent backends store one row per message keyed by thread. `HistoryTrimmer` keeps the thread inside the context window by estimating tokens and dropping the oldest messages first.
+
+### Trimming archives, it never deletes
+
+The durable backends (SQL, Eloquent, File) keep the messages trimmed out of the context window: a trim stamps them with `archived_at` (a nullable column on the messages table, a key on the file entry) and loading reads only the unarchived ones, so the full transcript stays available to the application while the model sees the trimmed thread. `flushAll()` is the one destructive operation: it removes the whole thread, archived messages included. `InMemoryChatHistory` simply drops what it trims.
 
 ### Identity: histories are bound, not identity-constructed
 

--- a/src/Chat/AGENTS.md
+++ b/src/Chat/AGENTS.md
@@ -17,7 +17,7 @@ new UserMessage([
 
 ## Chat history
 
-`AbstractChatHistory` implements the logic once; backends persist through one protected hook per primitive mutation, append (`onNewMessage`), head-trim (`onTrimHistory`, handed the trimmed messages) and clear, or ignore the hooks and rewrite the whole state via `setMessages()` (File, InMemory). SQL and Eloquent backends store one row per message keyed by thread. `HistoryTrimmer` keeps the thread inside the context window by estimating tokens and dropping the oldest messages first.
+`AbstractChatHistory` implements the logic once; backends persist through one protected hook per primitive mutation, append (`onNewMessage`), head-trim (`onTrimHistory`, invoked before the in-memory history drops the trimmed head) and clear, or ignore the hooks and rewrite the whole state via `setMessages()` (File, InMemory). SQL and Eloquent backends store one row per message keyed by thread. `HistoryTrimmer` keeps the thread inside the context window by estimating tokens and dropping the oldest messages first.
 
 ### Trimming archives, it never deletes
 

--- a/src/Chat/History/AbstractChatHistory.php
+++ b/src/Chat/History/AbstractChatHistory.php
@@ -28,6 +28,7 @@ use NeuronAI\Tools\ToolCall;
 use NeuronAI\Tools\ToolOutput;
 
 use function array_map;
+use function array_slice;
 use function count;
 use function end;
 use function is_array;
@@ -127,9 +128,11 @@ abstract class AbstractChatHistory implements ChatHistoryInterface
     }
 
     /**
-     * Backend hook: remove the persisted messages from position zero up to $index (exclusive).
+     * Backend hook: the messages trimmed away from the head of the thread, oldest first.
+     *
+     * @param Message[] $messages
      */
-    protected function onTrimHistory(int $index): void
+    protected function onTrimHistory(array $messages): void
     {
     }
 
@@ -162,11 +165,11 @@ abstract class AbstractChatHistory implements ChatHistoryInterface
     {
         $trimmed = $this->trimmer->trim($this->history, $this->contextWindow);
 
-        $skipIndex = count($this->history) - count($trimmed);
+        $removed = array_slice($this->history, 0, count($this->history) - count($trimmed));
 
-        if ($skipIndex > 0) {
+        if ($removed !== []) {
             $this->history = $trimmed;
-            $this->onTrimHistory($skipIndex);
+            $this->onTrimHistory($removed);
         }
     }
 

--- a/src/Chat/History/AbstractChatHistory.php
+++ b/src/Chat/History/AbstractChatHistory.php
@@ -28,7 +28,6 @@ use NeuronAI\Tools\ToolCall;
 use NeuronAI\Tools\ToolOutput;
 
 use function array_map;
-use function array_slice;
 use function count;
 use function end;
 use function is_array;
@@ -128,11 +127,11 @@ abstract class AbstractChatHistory implements ChatHistoryInterface
     }
 
     /**
-     * Backend hook: the messages trimmed away from the head of the thread, oldest first.
-     *
-     * @param Message[] $messages
+     * Backend hook: the messages from position zero up to $index (exclusive) fell out
+     * of the context window. Runs before $this->history drops them, so a backend can
+     * still read what is being trimmed.
      */
-    protected function onTrimHistory(array $messages): void
+    protected function onTrimHistory(int $index): void
     {
     }
 
@@ -165,11 +164,11 @@ abstract class AbstractChatHistory implements ChatHistoryInterface
     {
         $trimmed = $this->trimmer->trim($this->history, $this->contextWindow);
 
-        $removed = array_slice($this->history, 0, count($this->history) - count($trimmed));
+        $skipIndex = count($this->history) - count($trimmed);
 
-        if ($removed !== []) {
+        if ($skipIndex > 0) {
+            $this->onTrimHistory($skipIndex);
             $this->history = $trimmed;
-            $this->onTrimHistory($removed);
         }
     }
 

--- a/src/Chat/History/EloquentChatHistory.php
+++ b/src/Chat/History/EloquentChatHistory.php
@@ -10,8 +10,7 @@ use NeuronAI\Chat\Messages\Message;
 use NeuronAI\Exceptions\ChatHistoryException;
 
 use function array_merge;
-
-use const PHP_INT_MAX;
+use function count;
 
 class EloquentChatHistory extends AbstractChatHistory
 {
@@ -39,6 +38,7 @@ class EloquentChatHistory extends AbstractChatHistory
         $messages = $model->newQuery()
             ->select(['role', 'content', 'meta'])
             ->where('thread_id', $this->requireThreadId())
+            ->whereNull('archived_at')
             ->orderBy('id')
             ->get();
 
@@ -68,28 +68,22 @@ class EloquentChatHistory extends AbstractChatHistory
     /**
      * @throws ChatHistoryException
      */
-    protected function onTrimHistory(int $index): void
+    protected function onTrimHistory(array $messages): void
     {
-        if ($index <= 0) {
-            return;
-        }
-
         /** @var Model $model */
         $model = new $this->modelClass();
 
-        // Get the IDs of messages to keep (skip the first $index messages)
-        $idsToKeep = $model->newQuery()
+        // Archive the oldest unarchived messages of the thread.
+        $ids = $model->newQuery()
             ->where('thread_id', $this->requireThreadId())
+            ->whereNull('archived_at')
             ->orderBy('id')
-            ->offset($index)
-            ->limit(PHP_INT_MAX)
+            ->limit(count($messages))
             ->pluck('id');
 
-        // Delete messages not in the keep list
         $model->newQuery()
-            ->where('thread_id', $this->requireThreadId())
-            ->whereNotIn('id', $idsToKeep)
-            ->delete();
+            ->whereIn('id', $ids)
+            ->update(['archived_at' => $model->freshTimestampString()]);
     }
 
     /**

--- a/src/Chat/History/EloquentChatHistory.php
+++ b/src/Chat/History/EloquentChatHistory.php
@@ -10,7 +10,6 @@ use NeuronAI\Chat\Messages\Message;
 use NeuronAI\Exceptions\ChatHistoryException;
 
 use function array_merge;
-use function count;
 
 class EloquentChatHistory extends AbstractChatHistory
 {
@@ -68,17 +67,21 @@ class EloquentChatHistory extends AbstractChatHistory
     /**
      * @throws ChatHistoryException
      */
-    protected function onTrimHistory(array $messages): void
+    protected function onTrimHistory(int $index): void
     {
+        if ($index <= 0) {
+            return;
+        }
+
         /** @var Model $model */
         $model = new $this->modelClass();
 
-        // Archive the oldest unarchived messages of the thread.
+        // Archive the first $index unarchived messages of the thread.
         $ids = $model->newQuery()
             ->where('thread_id', $this->requireThreadId())
             ->whereNull('archived_at')
             ->orderBy('id')
-            ->limit(count($messages))
+            ->limit($index)
             ->pluck('id');
 
         $model->newQuery()

--- a/src/Chat/History/FileChatHistory.php
+++ b/src/Chat/History/FileChatHistory.php
@@ -7,6 +7,7 @@ namespace NeuronAI\Chat\History;
 use NeuronAI\Exceptions\ChatHistoryException;
 
 use function array_merge;
+use function array_slice;
 use function date;
 use function file_exists;
 use function file_get_contents;
@@ -78,11 +79,11 @@ class FileChatHistory extends AbstractChatHistory
         $this->history = $this->deserializeMessages($active);
     }
 
-    protected function onTrimHistory(array $messages): void
+    protected function onTrimHistory(int $index): void
     {
         $archivedAt = date(DATE_ATOM);
 
-        foreach ($messages as $message) {
+        foreach (array_slice($this->history, 0, $index) as $message) {
             $this->archived[] = array_merge($message->jsonSerialize(), ['archived_at' => $archivedAt]);
         }
     }

--- a/src/Chat/History/FileChatHistory.php
+++ b/src/Chat/History/FileChatHistory.php
@@ -6,6 +6,8 @@ namespace NeuronAI\Chat\History;
 
 use NeuronAI\Exceptions\ChatHistoryException;
 
+use function array_merge;
+use function date;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
@@ -16,11 +18,24 @@ use function json_encode;
 use function unlink;
 use function mkdir;
 
+use const DATE_ATOM;
 use const DIRECTORY_SEPARATOR;
 use const LOCK_EX;
 
+/**
+ * Stores the whole thread in one JSON file. Messages trimmed out of the context
+ * window stay in the file marked by archived_at, and only the unarchived entries
+ * are loaded back.
+ */
 class FileChatHistory extends AbstractChatHistory
 {
+    /**
+     * Serialized entries of the archived messages, written back on every save.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    protected array $archived = [];
+
     /**
      * @throws ChatHistoryException
      */
@@ -46,9 +61,29 @@ class FileChatHistory extends AbstractChatHistory
 
     protected function loadThread(): void
     {
-        if (is_file($this->getFilePath())) {
-            $messages = json_decode(file_get_contents($this->getFilePath()), true) ?? [];
-            $this->history = $this->deserializeMessages($messages);
+        if (!is_file($this->getFilePath())) {
+            return;
+        }
+
+        $active = [];
+
+        foreach (json_decode(file_get_contents($this->getFilePath()), true) ?? [] as $entry) {
+            if (isset($entry['archived_at'])) {
+                $this->archived[] = $entry;
+            } else {
+                $active[] = $entry;
+            }
+        }
+
+        $this->history = $this->deserializeMessages($active);
+    }
+
+    protected function onTrimHistory(array $messages): void
+    {
+        $archivedAt = date(DATE_ATOM);
+
+        foreach ($messages as $message) {
+            $this->archived[] = array_merge($message->jsonSerialize(), ['archived_at' => $archivedAt]);
         }
     }
 
@@ -73,6 +108,8 @@ class FileChatHistory extends AbstractChatHistory
      */
     protected function clear(): void
     {
+        $this->archived = [];
+
         if (file_exists($this->getFilePath()) && !unlink($this->getFilePath())) {
             throw new ChatHistoryException("Unable to delete the file '{$this->getFilePath()}'");
         }
@@ -83,7 +120,7 @@ class FileChatHistory extends AbstractChatHistory
      */
     protected function updateFile(): void
     {
-        $content = json_encode($this->jsonSerialize());
+        $content = json_encode([...$this->archived, ...$this->history]);
         $filePath = $this->getFilePath();
 
         // Try to write with LOCK_EX first for thread safety

--- a/src/Chat/History/SQLChatHistory.php
+++ b/src/Chat/History/SQLChatHistory.php
@@ -94,13 +94,15 @@ class SQLChatHistory extends AbstractChatHistory
     /**
      * @throws ChatHistoryException
      */
-    protected function onTrimHistory(array $messages): void
+    protected function onTrimHistory(int $index): void
     {
-        $limit = count($messages);
+        if ($index <= 0) {
+            return;
+        }
 
-        // Archive the oldest unarchived messages of the thread.
+        // Archive the first $index unarchived messages of the thread.
         $stmt = $this->pdo->prepare(
-            "SELECT id FROM {$this->table} WHERE thread_id = :thread_id AND archived_at IS NULL ORDER BY id LIMIT {$limit}"
+            "SELECT id FROM {$this->table} WHERE thread_id = :thread_id AND archived_at IS NULL ORDER BY id LIMIT {$index}"
         );
         $stmt->execute(['thread_id' => $this->requireThreadId()]);
         $ids = $stmt->fetchAll(PDO::FETCH_COLUMN);

--- a/src/Chat/History/SQLChatHistory.php
+++ b/src/Chat/History/SQLChatHistory.php
@@ -20,7 +20,9 @@ use function preg_match;
 use function trim;
 
 /**
- * Stores one row per message, associated to a thread_id.
+ * Stores one row per message, associated to a thread_id. Messages trimmed out of
+ * the context window are archived (archived_at) rather than deleted, and only
+ * the unarchived ones are loaded back.
  *
  * CREATE TABLE chat_messages (
  * id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
@@ -28,6 +30,7 @@ use function trim;
  * role VARCHAR(32) NOT NULL,
  * content LONGTEXT NULL,
  * meta LONGTEXT NULL,
+ * archived_at DATETIME NULL,
  * created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
  * updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  *
@@ -61,7 +64,9 @@ class SQLChatHistory extends AbstractChatHistory
      */
     protected function loadThread(): void
     {
-        $stmt = $this->pdo->prepare("SELECT role, content, meta FROM {$this->table} WHERE thread_id = :thread_id ORDER BY id");
+        $stmt = $this->pdo->prepare(
+            "SELECT role, content, meta FROM {$this->table} WHERE thread_id = :thread_id AND archived_at IS NULL ORDER BY id"
+        );
         $stmt->execute(['thread_id' => $this->requireThreadId()]);
         $records = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
@@ -89,14 +94,14 @@ class SQLChatHistory extends AbstractChatHistory
     /**
      * @throws ChatHistoryException
      */
-    protected function onTrimHistory(int $index): void
+    protected function onTrimHistory(array $messages): void
     {
-        if ($index <= 0) {
-            return;
-        }
+        $limit = count($messages);
 
-        // Delete the first $index messages of the thread.
-        $stmt = $this->pdo->prepare("SELECT id FROM {$this->table} WHERE thread_id = :thread_id ORDER BY id LIMIT {$index}");
+        // Archive the oldest unarchived messages of the thread.
+        $stmt = $this->pdo->prepare(
+            "SELECT id FROM {$this->table} WHERE thread_id = :thread_id AND archived_at IS NULL ORDER BY id LIMIT {$limit}"
+        );
         $stmt->execute(['thread_id' => $this->requireThreadId()]);
         $ids = $stmt->fetchAll(PDO::FETCH_COLUMN);
 
@@ -105,7 +110,9 @@ class SQLChatHistory extends AbstractChatHistory
         }
 
         $placeholders = implode(',', array_fill(0, count($ids), '?'));
-        $stmt = $this->pdo->prepare("DELETE FROM {$this->table} WHERE id IN ({$placeholders})");
+        $stmt = $this->pdo->prepare(
+            "UPDATE {$this->table} SET archived_at = CURRENT_TIMESTAMP WHERE id IN ({$placeholders})"
+        );
         $stmt->execute($ids);
     }
 

--- a/tests/Agent/AgentDurableHistoryTest.php
+++ b/tests/Agent/AgentDurableHistoryTest.php
@@ -47,7 +47,7 @@ class AgentDurableHistoryTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
 
         $searchTool = new SearchTool();
@@ -217,7 +217,7 @@ class AgentDurableHistoryTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
 
         $searchTool = new SearchTool();

--- a/tests/Agent/AgentResumeTest.php
+++ b/tests/Agent/AgentResumeTest.php
@@ -42,7 +42,7 @@ class AgentResumeTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
 
         return $pdo;

--- a/tests/Agent/AgentThreadContinuationTest.php
+++ b/tests/Agent/AgentThreadContinuationTest.php
@@ -149,7 +149,7 @@ class AgentThreadContinuationTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
         $persistence = new InMemoryPersistence();
         $searchTool = new SearchTool();

--- a/tests/Agent/ThreadIdentityTest.php
+++ b/tests/Agent/ThreadIdentityTest.php
@@ -39,7 +39,7 @@ class ThreadIdentityTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
         $persistence = $this->retainingPersistence();
 
@@ -73,7 +73,7 @@ class ThreadIdentityTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
 
         $agent = Agent::make(threadId: 'thread-4');
@@ -132,7 +132,7 @@ class ThreadIdentityTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
         $second = Agent::make(workflowId: 'thread-42');
         $second->setAiProvider(new FakeAIProvider());
@@ -153,7 +153,7 @@ class ThreadIdentityTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
         $persistence = new InMemoryPersistence();
 
@@ -297,7 +297,7 @@ class ThreadIdentityTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
         $provider = new FakeAIProvider(new AssistantMessage('First reply'), new AssistantMessage('Second reply'));
         $agent = Agent::make(threadId: 'thread-a')->setAiProvider($provider)->setInstructions('test');
@@ -398,7 +398,7 @@ class ThreadIdentityTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
 
         $agent = Agent::make();
@@ -441,7 +441,7 @@ class ThreadIdentityTest extends TestCase
                 $pdo = new PDO('sqlite::memory:');
                 $pdo->exec('CREATE TABLE chat_messages (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    thread_id TEXT, role TEXT, content TEXT, meta TEXT
+                    thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
                 )');
 
                 return new SQLChatHistory($pdo);

--- a/tests/Chat/History/EloquentChatHistoryTest.php
+++ b/tests/Chat/History/EloquentChatHistoryTest.php
@@ -45,6 +45,7 @@ class EloquentChatHistoryTest extends TestCase
             $table->string('role');
             $table->json('content')->nullable();
             $table->json('meta')->nullable();
+            $table->timestamp('archived_at')->nullable();
             $table->timestamps();
 
             $table->index('thread_id');
@@ -164,14 +165,7 @@ class EloquentChatHistoryTest extends TestCase
         // Create history with small context window
         $smallHistory = new EloquentChatHistory(ChatMessage::class, $this->threadId, contextWindow: 100);
 
-        // Add many messages to exceed context window
-        // Start with UserMessage (i=1 is odd) to create valid sequence
-        for ($i = 1; $i <= 20; $i++) {
-            $message = $i % 2 === 1
-                ? new UserMessage("User message $i with some text")
-                : (new AssistantMessage("Assistant message $i with some text"))->setUsage(new Usage(100 * $i, 150));
-            $smallHistory->addMessage($message);
-        }
+        $this->addMessagesBeyondContextWindow($smallHistory);
 
         $messages = $smallHistory->getMessages();
 
@@ -182,9 +176,39 @@ class EloquentChatHistoryTest extends TestCase
         // First message should be a user message (valid sequence)
         $this->assertInstanceOf(UserMessage::class, $messages[0]);
 
-        // Note: The database may have more messages than memory during the addition process
-        // This test mainly verifies that truncation happens in memory
-        // Database synchronization behavior may vary based on implementation
+        // The trimmed messages are archived in the database, not deleted
+        $rows = ChatMessage::query()->where('thread_id', $this->threadId);
+        $this->assertEquals(count($messages), (clone $rows)->whereNull('archived_at')->count());
+        $this->assertEquals(20 - count($messages), (clone $rows)->whereNotNull('archived_at')->count());
+    }
+
+    public function test_loads_only_unarchived_messages(): void
+    {
+        $smallHistory = new EloquentChatHistory(ChatMessage::class, $this->threadId, contextWindow: 100);
+
+        $this->addMessagesBeyondContextWindow($smallHistory);
+
+        $active = $smallHistory->getMessages();
+
+        $reloaded = new EloquentChatHistory(ChatMessage::class, $this->threadId);
+        $messages = $reloaded->getMessages();
+
+        $this->assertCount(count($active), $messages);
+        $this->assertEquals($active[0]->getContent(), $messages[0]->getContent());
+    }
+
+    /**
+     * Twenty alternating messages whose usage grows past a 100 tokens context window.
+     */
+    protected function addMessagesBeyondContextWindow(EloquentChatHistory $history): void
+    {
+        // Start with UserMessage (i=1 is odd) to create valid sequence
+        for ($i = 1; $i <= 20; $i++) {
+            $message = $i % 2 === 1
+                ? new UserMessage("User message $i with some text")
+                : (new AssistantMessage("Assistant message $i with some text"))->setUsage(new Usage(100 * $i, 150));
+            $history->addMessage($message);
+        }
     }
 
     public function test_multiple_threads_are_isolated(): void

--- a/tests/Chat/History/FileChatHistoryTest.php
+++ b/tests/Chat/History/FileChatHistoryTest.php
@@ -6,11 +6,17 @@ namespace NeuronAI\Tests\Chat\History;
 
 use NeuronAI\Chat\History\FileChatHistory;
 use NeuronAI\Chat\Messages\AssistantMessage;
+use NeuronAI\Chat\Messages\Usage;
 use NeuronAI\Chat\Messages\UserMessage;
 use PHPUnit\Framework\TestCase;
 
+use function array_filter;
+use function count;
 use function file_get_contents;
 use function json_decode;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -34,5 +40,52 @@ class FileChatHistoryTest extends TestCase
         $history->flushAll();
         $this->assertFileDoesNotExist(__DIR__.DIRECTORY_SEPARATOR.'neuron_test.chat');
         $this->assertCount(0, $history->getMessages());
+    }
+
+    public function test_trimmed_messages_are_archived_in_the_file(): void
+    {
+        $directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'neuron_archive_' . uniqid();
+        $file = $directory . DIRECTORY_SEPARATOR . 'neuron_archive.chat';
+
+        $history = new FileChatHistory($directory, 'archive', contextWindow: 100);
+
+        for ($i = 1; $i <= 20; $i++) {
+            $history->addMessage($i % 2 !== 0
+                ? new UserMessage("User message $i with some text")
+                : (new AssistantMessage("Assistant message $i with some text"))->setUsage(new Usage(100 * $i, 150)));
+        }
+
+        $active = $history->getMessages();
+        $this->assertLessThan(20, count($active));
+
+        // Every message is still in the file: the trimmed ones marked as archived, oldest first.
+        $entries = json_decode(file_get_contents($file), true);
+        $this->assertCount(20, $entries);
+        $this->assertCount(20 - count($active), $this->archivedEntries($entries));
+        $this->assertSame('User message 1 with some text', $entries[0]['content'][0]['content']);
+
+        // Only the unarchived entries are loaded back.
+        $reloaded = new FileChatHistory($directory, 'archive');
+        $this->assertCount(count($active), $reloaded->getMessages());
+        $this->assertSame($active[0]->getContent(), $reloaded->getMessages()[0]->getContent());
+
+        // The archived entries survive the next write.
+        $reloaded->addMessage(new UserMessage('One more message'));
+        $entries = json_decode(file_get_contents($file), true);
+        $this->assertCount(21, $entries);
+        $this->assertCount(21 - count($reloaded->getMessages()), $this->archivedEntries($entries));
+
+        $reloaded->flushAll();
+        $this->assertFileDoesNotExist($file);
+        rmdir($directory);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $entries
+     * @return array<int, array<string, mixed>>
+     */
+    protected function archivedEntries(array $entries): array
+    {
+        return array_filter($entries, fn (array $entry): bool => isset($entry['archived_at']));
     }
 }

--- a/tests/Chat/History/SQLChatHistoryTest.php
+++ b/tests/Chat/History/SQLChatHistoryTest.php
@@ -44,6 +44,7 @@ class SQLChatHistoryTest extends TestCase
           role VARCHAR(32) NOT NULL,
           content LONGTEXT NULL,
           meta LONGTEXT NULL,
+          archived_at DATETIME NULL,
           created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
           updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 
@@ -114,13 +115,7 @@ class SQLChatHistoryTest extends TestCase
         // Create history with small context window
         $smallHistory = new SQLChatHistory(pdo: $this->pdo, threadId: $this->threadId, contextWindow: 100);
 
-        // Add many messages to exceed context window
-        for ($i = 1; $i <= 20; $i++) {
-            $message = $i % 2 !== 0
-                ? new UserMessage("User message $i with some text")
-                : (new AssistantMessage("Assistant message $i with some text"))->setUsage(new Usage(100 * $i, 150));
-            $smallHistory->addMessage($message);
-        }
+        $this->addMessagesBeyondContextWindow($smallHistory);
 
         $messages = $smallHistory->getMessages();
 
@@ -131,11 +126,45 @@ class SQLChatHistoryTest extends TestCase
         // First message should be a user message (valid sequence)
         $this->assertInstanceOf(UserMessage::class, $messages[0]);
 
-        // The trimmed messages must also be deleted from the database
-        $stmt = $this->pdo->prepare("SELECT COUNT(*) as count FROM chat_messages WHERE thread_id = :thread_id");
+        // The trimmed messages are archived in the database, not deleted
+        $this->assertEquals(count($messages), $this->countRows('archived_at IS NULL'));
+        $this->assertEquals(20 - count($messages), $this->countRows('archived_at IS NOT NULL'));
+    }
+
+    public function test_loads_only_unarchived_messages(): void
+    {
+        $smallHistory = new SQLChatHistory(pdo: $this->pdo, threadId: $this->threadId, contextWindow: 100);
+
+        $this->addMessagesBeyondContextWindow($smallHistory);
+
+        $active = $smallHistory->getMessages();
+
+        $reloaded = new SQLChatHistory($this->pdo, $this->threadId);
+        $messages = $reloaded->getMessages();
+
+        $this->assertCount(count($active), $messages);
+        $this->assertEquals($active[0]->getContent(), $messages[0]->getContent());
+    }
+
+    /**
+     * Twenty alternating messages whose usage grows past a 100 tokens context window.
+     */
+    protected function addMessagesBeyondContextWindow(SQLChatHistory $history): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            $message = $i % 2 !== 0
+                ? new UserMessage("User message $i with some text")
+                : (new AssistantMessage("Assistant message $i with some text"))->setUsage(new Usage(100 * $i, 150));
+            $history->addMessage($message);
+        }
+    }
+
+    protected function countRows(string $condition): int
+    {
+        $stmt = $this->pdo->prepare("SELECT COUNT(*) FROM chat_messages WHERE thread_id = :thread_id AND {$condition}");
         $stmt->execute(['thread_id' => $this->threadId]);
-        $result = $stmt->fetch(PDO::FETCH_ASSOC);
-        $this->assertEquals(count($messages), $result['count']);
+
+        return (int) $stmt->fetchColumn();
     }
 
     public function test_adds_one_row_per_message(): void

--- a/tests/Chat/History/ThreadBindingTest.php
+++ b/tests/Chat/History/ThreadBindingTest.php
@@ -55,7 +55,7 @@ class ThreadBindingTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE chat_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            thread_id TEXT, role TEXT, content TEXT, meta TEXT
+            thread_id TEXT, role TEXT, content TEXT, meta TEXT, archived_at TEXT
         )');
 
         return $pdo;

--- a/upgrade/20-chat-history-archival.md
+++ b/upgrade/20-chat-history-archival.md
@@ -1,0 +1,80 @@
+# Upgrade: Trimmed chat messages are archived, not deleted
+
+## Summary
+
+`SQLChatHistory`, `EloquentChatHistory` and `FileChatHistory` no longer delete the
+messages trimmed out of the context window. A trim marks them with an `archived_at`
+timestamp and leaves them in place, and the history loads only the unarchived
+messages. The full transcript of a thread stays available to your application
+(auditing, analytics, retention policies) while the model keeps seeing the trimmed
+thread.
+
+`flushAll()` is unchanged: it still removes the whole thread, archived messages
+included. `InMemoryChatHistory` is unchanged as well.
+
+This is a breaking change for the two database backends: the `chat_messages` table
+needs a nullable `archived_at` column, and both backends filter on it when loading.
+
+## 1. Add the `archived_at` column
+
+MySQL:
+
+```sql
+ALTER TABLE chat_messages ADD COLUMN archived_at DATETIME NULL AFTER meta;
+```
+
+PostgreSQL:
+
+```sql
+ALTER TABLE chat_messages ADD COLUMN archived_at TIMESTAMP NULL;
+```
+
+SQLite:
+
+```sql
+ALTER TABLE chat_messages ADD COLUMN archived_at TEXT NULL;
+```
+
+Laravel migration (Eloquent):
+
+```php
+Schema::table('chat_messages', function (Blueprint $table) {
+    $table->timestamp('archived_at')->nullable()->after('meta');
+});
+```
+
+`SQLChatHistory` archives with the database `CURRENT_TIMESTAMP`; `EloquentChatHistory`
+writes the model's fresh timestamp, so the column follows your model's date format.
+
+## 2. File histories
+
+Nothing to migrate. Archived entries are written to the same `.chat` file with an
+`archived_at` key (ISO 8601). Files written before this change contain only
+unarchived entries and load as before.
+
+## 3. Custom backends
+
+If you extend `AbstractChatHistory`, the trim hook now receives the trimmed messages
+(oldest first) instead of their count:
+
+Before:
+
+```php
+protected function onTrimHistory(int $index): void
+```
+
+After:
+
+```php
+/**
+ * @param Message[] $messages
+ */
+protected function onTrimHistory(array $messages): void
+```
+
+## What to search for
+
+```
+grep -rn "onTrimHistory" --include="*.php" .
+grep -rn "chat_messages" --include="*.php" --include="*.sql" .
+```

--- a/upgrade/20-chat-history-archival.md
+++ b/upgrade/20-chat-history-archival.md
@@ -52,29 +52,8 @@ Nothing to migrate. Archived entries are written to the same `.chat` file with a
 `archived_at` key (ISO 8601). Files written before this change contain only
 unarchived entries and load as before.
 
-## 3. Custom backends
-
-If you extend `AbstractChatHistory`, the trim hook now receives the trimmed messages
-(oldest first) instead of their count:
-
-Before:
-
-```php
-protected function onTrimHistory(int $index): void
-```
-
-After:
-
-```php
-/**
- * @param Message[] $messages
- */
-protected function onTrimHistory(array $messages): void
-```
-
 ## What to search for
 
 ```
-grep -rn "onTrimHistory" --include="*.php" .
 grep -rn "chat_messages" --include="*.php" --include="*.sql" .
 ```


### PR DESCRIPTION
## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🔧 Improvement/Enhancement (non-breaking change which improves existing functionality)
- [ ] 📖 Documentation update
- [ ] 🧹 Code cleanup/refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

### What does this PR do?

`SQLChatHistory`, `EloquentChatHistory` and `FileChatHistory` no longer delete the messages trimmed out of the context window. A trim now marks them as archived, and loading reads only the unarchived messages:

- **SQL** selects the first `$index` unarchived rows of the thread and sets `archived_at = CURRENT_TIMESTAMP` on them; `loadThread()` filters on `archived_at IS NULL`.
- **Eloquent** does the same through the query builder, writing the model's fresh timestamp so the column follows the model's date format.
- **File** keeps the archived entries in the same `.chat` file with an ISO 8601 `archived_at` key, written ahead of the live messages, and splits them out on load.
- **AbstractChatHistory** keeps the `onTrimHistory(int $index)` hook unchanged; it is now invoked before the in-memory history drops the trimmed head, which is what lets the file backend read the messages it archives.

`flushAll()` is unchanged and still removes the whole thread, archived messages included. `InMemoryChatHistory` is untouched.

### Why is this change needed?

Trimming exists to keep the model's context inside its window, not to erase the conversation. Deleting the trimmed rows lost the transcript for auditing, analytics and retention policies. Archiving keeps the full thread in storage while the model keeps seeing the trimmed one.

### How does this change should be used and documented?

Nothing changes in how histories are used. Database users add a nullable `archived_at` column to the messages table; file histories need no migration (files written before this change contain only live entries and load as before). Documented in `upgrade/20-chat-history-archival.md` (ALTER statements for MySQL, PostgreSQL and SQLite plus a Laravel migration snippet), in the schema docblock of `SQLChatHistory`, and in `src/Chat/AGENTS.md`.

## Related Issues

- None

## Testing

- [x] I have tested this change locally
- [x] I have added/updated unit tests where appropriate
- [x] All existing tests pass
- [ ] I have tested this with different PHP versions (if applicable)

New tests for each backend cover that trimmed messages are archived rather than deleted, that a fresh instance loads only the unarchived ones, and (file backend) that archived entries survive later writes. Every SQLite schema used by the agent tests gained the new column.

MySQL is not reachable in my environment, so `SQLChatHistoryTest` was skipped locally; I ran the same suite against SQLite through a scratch copy and it passes. The Calculator toolkit tests error locally only because `ext-bcmath` is missing in my container; everything else in the suite passes. PHPStan, php-cs-fixer and rector are clean.

## Breaking Changes

- [ ] No breaking changes
- [x] Yes, this PR introduces breaking changes (explain below)

**If yes, describe the breaking changes and migration path:**

The `chat_messages` table needs a nullable `archived_at` column; both database backends filter on it when loading. Migration statements are in `upgrade/20-chat-history-archival.md`. Custom backends extending `AbstractChatHistory` are unaffected: the hook signatures are unchanged.

## Documentation

- [ ] No documentation changes needed
- [x] I have updated relevant documentation
- [ ] Documentation will be updated in a separate PR
- [ ] New documentation needs to be created

## Checklist

- [x] My code follows the project's coding standards (PHPStan)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] My commit messages are clear and descriptive
- [x] This PR addresses only ONE specific goal/issue

## Additional Notes

`flushAll()` was deliberately left destructive since the request was scoped to trimming; if archiving should apply there too, it is a one-line change per backend. No index was added on `archived_at`: the existing `thread_id` index already narrows the scan to one thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtgRYbxHQGYYvdF9hmzcc7